### PR TITLE
fix(config): キーラベル表示を小文字に統一する（esc）

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -247,8 +247,6 @@ func (k KeyBindings) labels(action Action) []string {
 
 func formatKeyLabel(key string) string {
 	switch key {
-	case "esc":
-		return "Esc"
 	case "up":
 		return "↑"
 	case "down":

--- a/internal/gui/layout/status_test.go
+++ b/internal/gui/layout/status_test.go
@@ -39,20 +39,20 @@ func TestFormatStatusLine(t *testing.T) {
 			diffMode:  true,
 			focus:     FocusReviewDrawer,
 			inputMode: model.ReviewInputComment,
-			want:      "[q]Quit [?]Help | [ctrl+s]Save Comment [Esc]Cancel",
+			want:      "[q]Quit [?]Help | [ctrl+s]Save Comment [esc]Cancel",
 		},
 		{
 			name:      "review input summary",
 			diffMode:  true,
 			focus:     FocusReviewDrawer,
 			inputMode: model.ReviewInputSummary,
-			want:      "[q]Quit [?]Help | [ctrl+s]Save Summary [Esc]Cancel",
+			want:      "[q]Quit [?]Help | [ctrl+s]Save Summary [esc]Cancel",
 		},
 		{
 			name:     "review drawer focus",
 			diffMode: true,
 			focus:    FocusReviewDrawer,
-			want:     "[q]Quit [?]Help | [Review] [ctrl+r]Submit [X]Discard [Esc]Cancel",
+			want:     "[q]Quit [?]Help | [Review] [ctrl+r]Submit [X]Discard [esc]Cancel",
 		},
 	}
 


### PR DESCRIPTION
## Summary

- `formatKeyLabel` から `esc` → `Esc` の変換ケースを削除し、`default` へフォールスルーさせることで小文字のまま表示
- `status_test.go` の期待値を `[Esc]Cancel` → `[esc]Cancel` に更新

## Test plan

- [x] `go fmt ./...` 実行済み
- [x] `go vet ./...` 実行済み
- [x] `go test ./...` 全テスト通過

Closes #47