### PR TITLE
refactor: Loading 系の命名・文言を Fetching に統一する

### DIFF
--- a/internal/gui/fetch_test.go
+++ b/internal/gui/fetch_test.go
@@ -188,15 +188,15 @@ func TestApplyPRsResult(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewGui failed: %v", err)
 			}
-			g.state.BeginLoadPRs()
+			g.state.BeginFetchPRs()
 
 			g.applyPRsResult(tt.msg)
 
 			if g.state.Fetching {
 				t.Fatal("expected PRsLoading=false")
 			}
-			if g.state.Overview.Loading != model.LoadingNone {
-				t.Fatalf("got %v, want %v", g.state.Overview.Loading, model.LoadingNone)
+			if g.state.Overview.Fetching != model.FetchNone {
+				t.Fatalf("got %v, want %v", g.state.Overview.Fetching, model.FetchNone)
 			}
 			if g.state.Repo != tt.want.repo {
 				t.Fatalf("got %q, want %q", g.state.Repo, tt.want.repo)
@@ -252,12 +252,12 @@ func TestApplyDetailResult(t *testing.T) {
 				t.Fatalf("NewGui failed: %v", err)
 			}
 			g.state.ApplyPRsResult("owner/repo", []model.Item{{Number: 1, Title: "Fix bug"}}, nil)
-			g.state.Overview.Loading = model.LoadingDetail
+			g.state.Overview.Fetching = model.FetchingDetail
 
 			g.applyDetailResult(tt.msg)
 
-			if g.state.Overview.Loading != model.LoadingNone {
-				t.Fatalf("got %v, want %v", g.state.Overview.Loading, model.LoadingNone)
+			if g.state.Overview.Fetching != model.FetchNone {
+				t.Fatalf("got %v, want %v", g.state.Overview.Fetching, model.FetchNone)
 			}
 			if g.state.Overview.Content != tt.want.detail {
 				t.Fatalf("got %q, want %q", g.state.Overview.Content, tt.want.detail)
@@ -273,7 +273,7 @@ func TestApplyDetailResult_DiffUsesSanitizedContent(t *testing.T) {
 	}
 	g.state.ApplyPRsResult("owner/repo", []model.Item{{Number: 1, Title: "Fix bug"}}, nil)
 	g.switchToDiff()
-	g.state.Overview.Loading = model.LoadingDetail
+	g.state.Overview.Fetching = model.FetchingDetail
 
 	raw := strings.Join([]string{
 		"diff --git a/a.txt b/a.txt",

--- a/internal/gui/input.go
+++ b/internal/gui/input.go
@@ -131,7 +131,7 @@ func (s *screen) handleFilterKey(msg tea.KeyMsg) tea.Cmd {
 		return nil
 	case "enter":
 		s.gui.state.CloseFilterSelect()
-		s.gui.state.BeginLoadPRs()
+		s.gui.state.BeginFetchPRs()
 		return s.loadPRsCmd()
 	case "j", "down":
 		s.gui.state.MoveFilterCursor(1)

--- a/internal/gui/layout/status.go
+++ b/internal/gui/layout/status.go
@@ -18,7 +18,7 @@ const (
 )
 
 type Status struct {
-	Loading   bool
+	Fetching  bool
 	DiffMode  bool
 	Focus     Focus
 	InputMode model.ReviewInputMode
@@ -43,8 +43,8 @@ func (s Status) String() string {
 	}
 
 	line := fmt.Sprintf("%s | %s", base, ctx)
-	if s.Loading {
-		return fmt.Sprintf("Loading... | %s", line)
+	if s.Fetching {
+		return fmt.Sprintf("Fetching... | %s", line)
 	}
 	return line
 }

--- a/internal/gui/layout/status_test.go
+++ b/internal/gui/layout/status_test.go
@@ -10,7 +10,7 @@ import (
 func TestFormatStatusLine(t *testing.T) {
 	tests := []struct {
 		name      string
-		loading   bool
+		fetching  bool
 		diffMode  bool
 		focus     Focus
 		inputMode model.ReviewInputMode
@@ -28,11 +28,11 @@ func TestFormatStatusLine(t *testing.T) {
 			want:     "[q]Quit [?]Help | [h/l]Panels [o]Overview",
 		},
 		{
-			name:     "loading",
-			loading:  true,
+			name:     "fetching",
+			fetching: true,
 			diffMode: true,
 			focus:    FocusDiffContent,
-			want:     "Loading... | [q]Quit [?]Help | [h/l]Panels [o]Overview",
+			want:     "Fetching... | [q]Quit [?]Help | [h/l]Panels [o]Overview",
 		},
 		{
 			name:      "review input comment",
@@ -59,7 +59,7 @@ func TestFormatStatusLine(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := Status{
-				Loading:   tt.loading,
+				Fetching:  tt.fetching,
 				DiffMode:  tt.diffMode,
 				Focus:     tt.focus,
 				InputMode: tt.inputMode,

--- a/internal/gui/render.go
+++ b/internal/gui/render.go
@@ -19,7 +19,7 @@ func (gui *Gui) render() string {
 	screen := layout.New(gui.state.Width, gui.state.Height, isDiff, showDrawer)
 	focus := gui.renderFocus()
 	statusLine := layout.Status{
-		Loading:   gui.state.Overview.Loading != model.LoadingNone,
+		Fetching:  gui.state.Overview.Fetching != model.FetchNone,
 		DiffMode:  isDiff,
 		Focus:     focus,
 		InputMode: gui.review.InputMode(),

--- a/internal/gui/screen.go
+++ b/internal/gui/screen.go
@@ -13,7 +13,7 @@ func (s *screen) Init() tea.Cmd {
 	if s.gui.client == nil {
 		return nil
 	}
-	s.gui.state.BeginLoadPRs()
+	s.gui.state.BeginFetchPRs()
 	return s.loadPRsCmd()
 }
 

--- a/internal/model/detail.go
+++ b/internal/model/detail.go
@@ -7,11 +7,11 @@ const (
 	DetailModeDiff
 )
 
-type LoadingKind int
+type FetchKind int
 
 const (
-	LoadingNone LoadingKind = iota
-	LoadingPRs
-	LoadingDetail
-	LoadingReview
+	FetchNone FetchKind = iota
+	FetchingPRs
+	FetchingDetail
+	FetchingReview
 )

--- a/internal/pr/overview/state.go
+++ b/internal/pr/overview/state.go
@@ -3,9 +3,9 @@ package overview
 
 import "github.com/rin2yh/lazygh/internal/model"
 
-// State holds overview panel display and loading state.
+// State holds overview panel display and fetching state.
 type State struct {
-	Mode    model.DetailMode
-	Content string
-	Loading model.LoadingKind
+	Mode     model.DetailMode
+	Content  string
+	Fetching model.FetchKind
 }

--- a/internal/review/controller.go
+++ b/internal/review/controller.go
@@ -27,8 +27,8 @@ type Selection interface {
 type AppState interface {
 	SelectedPR() (model.Item, bool)
 	ListRepo() string
-	BeginReviewLoad()
-	ClearLoading()
+	BeginFetchReview()
+	ClearFetching()
 	IsDiffMode() bool
 }
 

--- a/internal/review/controller_test.go
+++ b/internal/review/controller_test.go
@@ -17,10 +17,10 @@ func defaultTestConfig() *config.Config { return config.Default() }
 type fakeHost struct {
 	repo string
 	pr   *model.Item
-	// loading call counts
-	beginReviewLoadCalls int
-	clearLoadingCalls    int
-	diffMode             bool
+	// fetching call counts
+	beginFetchReviewCalls int
+	clearFetchingCalls    int
+	diffMode              bool
 }
 
 func (h *fakeHost) SelectedPR() (model.Item, bool) {
@@ -29,10 +29,10 @@ func (h *fakeHost) SelectedPR() (model.Item, bool) {
 	}
 	return *h.pr, true
 }
-func (h *fakeHost) ListRepo() string { return h.repo }
-func (h *fakeHost) BeginReviewLoad() { h.beginReviewLoadCalls++ }
-func (h *fakeHost) ClearLoading()    { h.clearLoadingCalls++ }
-func (h *fakeHost) IsDiffMode() bool { return h.diffMode }
+func (h *fakeHost) ListRepo() string  { return h.repo }
+func (h *fakeHost) BeginFetchReview() { h.beginFetchReviewCalls++ }
+func (h *fakeHost) ClearFetching()    { h.clearFetchingCalls++ }
+func (h *fakeHost) IsDiffMode() bool  { return h.diffMode }
 
 func setupControllerWithPR(client *testmock.GHClient, sel reviewstub.Selection) (*Controller, *fakeHost, *FocusTarget) {
 	host := &fakeHost{
@@ -104,7 +104,7 @@ func TestHandleSubmit_NoPendingReview(t *testing.T) {
 
 func TestApplySubmitResult_ErrorPreservesState(t *testing.T) {
 	c, host, _ := setupControllerWithPR(&testmock.GHClient{}, reviewstub.Selection{})
-	host.beginReviewLoadCalls = 0
+	host.beginFetchReviewCalls = 0
 	c.rs.SetContext(1, "PR_1", "abc123", "PRR_1")
 	c.rs.AddComment(model.ReviewComment{Path: "a.go", Body: "hi", Line: 10})
 

--- a/internal/review/pending.go
+++ b/internal/review/pending.go
@@ -88,7 +88,7 @@ func (f *pending) HandleCommentSave() tea.Cmd {
 		CommitOID:     f.rs.CommitOID,
 	}
 
-	f.host.BeginReviewLoad()
+	f.host.BeginFetchReview()
 	return func() tea.Msg {
 		var runErr error
 		if reviewID == "" {
@@ -147,7 +147,7 @@ func (f *pending) HandleDeleteComment() tea.Cmd {
 		return nil
 	}
 	commentID := comment.CommentID
-	f.host.BeginReviewLoad()
+	f.host.BeginFetchReview()
 	return func() tea.Msg {
 		err := f.client.DeletePendingReviewComment(commentID)
 		return CommentDeletedMsg{CommentID: commentID, Err: err}
@@ -172,7 +172,7 @@ func (f *pending) HandleEditCommentSave() tea.Cmd {
 		return nil
 	}
 	commentID := comment.CommentID
-	f.host.BeginReviewLoad()
+	f.host.BeginFetchReview()
 	return func() tea.Msg {
 		err := f.client.UpdatePendingReviewComment(commentID, body)
 		return CommentUpdatedMsg{Body: body, Err: err}
@@ -189,7 +189,7 @@ func (f *pending) HandleSubmit() tea.Cmd {
 		f.rs.SetNotice("No pending review to submit.")
 		return nil
 	}
-	f.host.BeginReviewLoad()
+	f.host.BeginFetchReview()
 	reviewID := f.rs.ReviewID
 	body := f.rs.Summary
 	repo := f.host.ListRepo()
@@ -221,7 +221,7 @@ func (f *pending) HandleDiscard() tea.Cmd {
 		f.rs.ResetAfterDiscard("Review draft discarded.")
 		return nil
 	}
-	f.host.BeginReviewLoad()
+	f.host.BeginFetchReview()
 	repo := f.host.ListRepo()
 	return func() tea.Msg {
 		err := f.client.DeletePendingReview(repo, reviewID)
@@ -232,7 +232,7 @@ func (f *pending) HandleDiscard() tea.Cmd {
 // ApplyCommentResult applies the result of a comment save operation and returns
 // true if the comment was saved successfully (caller should set focus to FocusReviewDrawer).
 func (f *pending) ApplyCommentResult(msg CommentSavedMsg) bool {
-	f.host.ClearLoading()
+	f.host.ClearFetching()
 	if msg.ReviewID != "" || msg.Context.PullRequestID != "" || msg.Context.CommitOID != "" {
 		f.rs.SetContext(msg.PRNumber, msg.Context.PullRequestID, msg.Context.CommitOID, msg.ReviewID)
 	}
@@ -254,7 +254,7 @@ func (f *pending) ApplyCommentResult(msg CommentSavedMsg) bool {
 }
 
 func (f *pending) ApplyDeleteCommentResult(msg CommentDeletedMsg) {
-	f.host.ClearLoading()
+	f.host.ClearFetching()
 	if msg.Err != nil {
 		f.rs.SetNotice(msg.Err.Error())
 		return
@@ -264,7 +264,7 @@ func (f *pending) ApplyDeleteCommentResult(msg CommentDeletedMsg) {
 }
 
 func (f *pending) ApplyEditCommentResult(msg CommentUpdatedMsg) {
-	f.host.ClearLoading()
+	f.host.ClearFetching()
 	if msg.Err != nil {
 		f.rs.SetNotice(msg.Err.Error())
 		return
@@ -274,7 +274,7 @@ func (f *pending) ApplyEditCommentResult(msg CommentUpdatedMsg) {
 }
 
 func (f *pending) ApplySubmitResult(msg SubmittedMsg) {
-	f.host.ClearLoading()
+	f.host.ClearFetching()
 	if msg.Err != nil {
 		f.rs.SetNotice(msg.Err.Error())
 		return
@@ -285,7 +285,7 @@ func (f *pending) ApplySubmitResult(msg SubmittedMsg) {
 }
 
 func (f *pending) ApplyDiscardResult(msg DiscardedMsg) {
-	f.host.ClearLoading()
+	f.host.ClearFetching()
 	if msg.Err != nil {
 		f.rs.SetNotice(msg.Err.Error())
 		return

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -40,24 +40,24 @@ func (s *State) SetWindowSize(width int, height int) {
 	s.Height = height
 }
 
-func (s *State) BeginLoadPRs() {
+func (s *State) BeginFetchPRs() {
 	s.Fetching = true
-	s.Overview.Loading = model.LoadingPRs
+	s.Overview.Fetching = model.FetchingPRs
 }
 
-// BeginReviewLoad marks a review operation as in-progress.
-func (s *State) BeginReviewLoad() {
-	s.Overview.Loading = model.LoadingReview
+// BeginFetchReview marks a review operation as in-progress.
+func (s *State) BeginFetchReview() {
+	s.Overview.Fetching = model.FetchingReview
 }
 
-// ClearLoading clears any in-progress loading indicator.
-func (s *State) ClearLoading() {
-	s.Overview.Loading = model.LoadingNone
+// ClearFetching clears any in-progress fetching indicator.
+func (s *State) ClearFetching() {
+	s.Overview.Fetching = model.FetchNone
 }
 
 func (s *State) ApplyPRsResult(repo string, items []model.Item, err error) {
 	s.Fetching = false
-	s.Overview.Loading = model.LoadingNone
+	s.Overview.Fetching = model.FetchNone
 	if err != nil {
 		s.showError("Error loading PRs", err)
 		return
@@ -81,7 +81,7 @@ func (s *State) ApplyDetailResult(content string, err error) {
 		s.showError("Error loading detail", err)
 		return
 	}
-	s.Overview.Loading = model.LoadingNone
+	s.Overview.Fetching = model.FetchNone
 	s.Overview.Content = model.SanitizeMultiline(content)
 }
 
@@ -90,7 +90,7 @@ func (s *State) ApplyDiffResult(content string, err error) {
 		s.showError("Error loading diff", err)
 		return
 	}
-	s.Overview.Loading = model.LoadingNone
+	s.Overview.Fetching = model.FetchNone
 	s.Overview.Content = model.SanitizeMultiline(content)
 }
 
@@ -123,7 +123,7 @@ func (s *State) SwitchToOverview() bool {
 		return false
 	}
 	s.Overview.Mode = model.DetailModeOverview
-	s.Overview.Loading = model.LoadingNone
+	s.Overview.Fetching = model.FetchNone
 	s.refreshOverviewPreview()
 	return true
 }
@@ -133,7 +133,7 @@ func (s *State) SwitchToDiff() bool {
 		return false
 	}
 	s.Overview.Mode = model.DetailModeDiff
-	s.Overview.Loading = model.LoadingNone
+	s.Overview.Fetching = model.FetchNone
 	return true
 }
 
@@ -161,11 +161,11 @@ func (s *State) PlanEnter(hasClient bool, forcedDetailText string) EnterAction {
 		return EnterAction{}
 	}
 	if forcedDetailText != "" {
-		s.Overview.Loading = model.LoadingNone
+		s.Overview.Fetching = model.FetchNone
 		s.Overview.Content = forcedDetailText
 		return EnterAction{}
 	}
-	s.Overview.Loading = model.LoadingDetail
+	s.Overview.Fetching = model.FetchingDetail
 	if s.Overview.Mode == model.DetailModeDiff {
 		return EnterAction{Kind: model.EnterLoadPRDiff, Repo: s.Repo, Number: item.Number}
 	}
@@ -189,7 +189,7 @@ func (s *State) selectedPR() (model.Item, bool) {
 }
 
 func (s *State) showError(msg string, err error) {
-	s.Overview.Loading = model.LoadingNone
+	s.Overview.Fetching = model.FetchNone
 	s.Overview.Content = model.SanitizeMultiline(fmt.Sprintf("%s: %v", msg, err))
 }
 

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -54,14 +54,14 @@ func TestApplyPRsResult(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := NewState()
-			s.BeginLoadPRs()
+			s.BeginFetchPRs()
 			s.ApplyPRsResult(tt.repo, tt.prs, tt.err)
 
 			if s.Fetching {
 				t.Fatal("prs should not be loading")
 			}
-			if s.Overview.Loading != model.LoadingNone {
-				t.Fatalf("got %v, want %v", s.Overview.Loading, model.LoadingNone)
+			if s.Overview.Fetching != model.FetchNone {
+				t.Fatalf("got %v, want %v", s.Overview.Fetching, model.FetchNone)
 			}
 			if s.Repo != tt.want.repo {
 				t.Fatalf("got %q, want %q", s.Repo, tt.want.repo)
@@ -79,17 +79,17 @@ func TestApplyPRsResult(t *testing.T) {
 	}
 }
 
-func TestBeginLoadPRs_OnlySetsLoadingState(t *testing.T) {
+func TestBeginFetchPRs_OnlySetsLoadingState(t *testing.T) {
 	s := NewState()
 	s.Overview.Content = "keep"
 
-	s.BeginLoadPRs()
+	s.BeginFetchPRs()
 
 	if !s.Fetching {
 		t.Fatal("expected PRsLoading to be true")
 	}
-	if s.Overview.Loading != model.LoadingPRs {
-		t.Fatalf("got %v, want %v", s.Overview.Loading, model.LoadingPRs)
+	if s.Overview.Fetching != model.FetchingPRs {
+		t.Fatalf("got %v, want %v", s.Overview.Fetching, model.FetchingPRs)
 	}
 	if s.Overview.Content != "keep" {
 		t.Fatalf("got %q, want %q", s.Overview.Content, "keep")
@@ -178,8 +178,8 @@ func TestPlanEnter_LoadPR(t *testing.T) {
 			if action.Number != 7 {
 				t.Fatalf("got %d, want %d", action.Number, 7)
 			}
-			if s.Overview.Loading != model.LoadingDetail {
-				t.Fatalf("got %v, want %v", s.Overview.Loading, model.LoadingDetail)
+			if s.Overview.Fetching != model.FetchingDetail {
+				t.Fatalf("got %v, want %v", s.Overview.Fetching, model.FetchingDetail)
 			}
 			if tt.wantKind == model.EnterLoadPRDetail {
 				if s.Overview.Content != before {
@@ -220,12 +220,12 @@ func TestApplyDetailResult(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := NewState()
-			s.Overview.Loading = model.LoadingDetail
+			s.Overview.Fetching = model.FetchingDetail
 
 			s.ApplyDetailResult(tt.content, tt.err)
 
-			if s.Overview.Loading != model.LoadingNone {
-				t.Fatalf("got %v, want %v", s.Overview.Loading, model.LoadingNone)
+			if s.Overview.Fetching != model.FetchNone {
+				t.Fatalf("got %v, want %v", s.Overview.Fetching, model.FetchNone)
 			}
 			if s.Overview.Content != tt.want.detail {
 				t.Fatalf("got %q, want %q", s.Overview.Content, tt.want.detail)
@@ -264,12 +264,12 @@ func TestApplyDiffResult(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := NewState()
-			s.Overview.Loading = model.LoadingDetail
+			s.Overview.Fetching = model.FetchingDetail
 
 			s.ApplyDiffResult(tt.content, tt.err)
 
-			if s.Overview.Loading != model.LoadingNone {
-				t.Fatalf("got %v, want %v", s.Overview.Loading, model.LoadingNone)
+			if s.Overview.Fetching != model.FetchNone {
+				t.Fatalf("got %v, want %v", s.Overview.Fetching, model.FetchNone)
 			}
 			if s.Overview.Content != tt.want.detail {
 				t.Fatalf("got %q, want %q", s.Overview.Content, tt.want.detail)


### PR DESCRIPTION
Closes #73

## 変更内容

- `model.LoadingKind` → `model.FetchKind`（定数: `FetchNone` / `FetchingPRs` / `FetchingDetail` / `FetchingReview`）
- `DetailState.Loading` → `DetailState.Fetching`
- `BeginLoadPRs()` → `BeginFetchPRs()`
- `BeginReviewLoad()` → `BeginFetchReview()`
- `ClearLoading()` → `ClearFetching()`
- `layout.Status.Loading` → `layout.Status.Fetching`
- UI 文言: `"Loading..."` → `"Fetching..."`

## 確認

- `go fmt ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅ (全パッケージ通過)