### PR TITLE
refactor: KeyBindings ラベルメソッドの重複を統合する

### DIFF
--- a/internal/app/layout/status.go
+++ b/internal/app/layout/status.go
@@ -26,20 +26,20 @@ type Status struct {
 }
 
 func (s Status) String() string {
-	base := fmt.Sprintf("[%s]Quit [%s]Help", s.Keys.QuitLabel(), s.Keys.HelpLabel())
+	base := fmt.Sprintf("[%s]Quit [%s]Help", s.Keys.PrimaryLabel(config.ActionQuit), s.Keys.PrimaryLabel(config.ActionShowHelp))
 
 	var ctx string
 	switch {
 	case s.InputMode == model.ReviewInputComment:
-		ctx = fmt.Sprintf("[%s]Save Comment [%s]Cancel", s.Keys.SaveLabel(), s.Keys.CancelLabel())
+		ctx = fmt.Sprintf("[%s]Save Comment [%s]Cancel", s.Keys.PrimaryLabel(config.ActionReviewSave), s.Keys.PrimaryLabel(config.ActionCancel))
 	case s.InputMode == model.ReviewInputSummary:
-		ctx = fmt.Sprintf("[%s]Save Summary [%s]Cancel", s.Keys.SaveLabel(), s.Keys.CancelLabel())
+		ctx = fmt.Sprintf("[%s]Save Summary [%s]Cancel", s.Keys.PrimaryLabel(config.ActionReviewSave), s.Keys.PrimaryLabel(config.ActionCancel))
 	case s.Focus == FocusReviewDrawer:
-		ctx = fmt.Sprintf("[Review] [%s]Submit [%s]Discard [%s]Cancel", s.Keys.SubmitLabel(), s.Keys.DiscardLabel(), s.Keys.CancelLabel())
+		ctx = fmt.Sprintf("[Review] [%s]Submit [%s]Discard [%s]Cancel", s.Keys.PrimaryLabel(config.ActionReviewSubmit), s.Keys.PrimaryLabel(config.ActionReviewDiscard), s.Keys.PrimaryLabel(config.ActionCancel))
 	case !s.DiffMode:
-		ctx = fmt.Sprintf("[%s]Panels [%s]Diff", s.Keys.PanelLabel(), s.Keys.DiffLabel())
+		ctx = fmt.Sprintf("[%s]Panels [%s]Diff", s.Keys.PanelLabel(), s.Keys.PrimaryLabel(config.ActionShowDiff))
 	default:
-		ctx = fmt.Sprintf("[%s]Panels [%s]Overview", s.Keys.PanelLabel(), s.Keys.OverviewLabel())
+		ctx = fmt.Sprintf("[%s]Panels [%s]Overview", s.Keys.PanelLabel(), s.Keys.PrimaryLabel(config.ActionShowOverview))
 	}
 
 	line := fmt.Sprintf("%s | %s", base, ctx)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -147,23 +147,11 @@ func (k KeyBindings) Label(action Action) string {
 }
 
 func (k KeyBindings) PrimaryLabel(action Action) string {
-	labels := k.labels(action)
-	if len(labels) == 0 {
+	keys := k.Binding(action).Keys
+	if len(keys) == 0 {
 		return ""
 	}
-	return labels[0]
-}
-
-func (k KeyBindings) QuitLabel() string {
-	return k.PrimaryLabel(ActionQuit)
-}
-
-func (k KeyBindings) ReloadLabel() string {
-	return k.PrimaryLabel(ActionOpenSelected)
-}
-
-func (k KeyBindings) FocusLabel() string {
-	return k.PrimaryLabel(ActionFocusNext)
+	return formatKeyLabel(keys[0])
 }
 
 func (k KeyBindings) MoveLabel() string {
@@ -190,50 +178,6 @@ func (k KeyBindings) PageLabel() string {
 
 func (k KeyBindings) TopBottomLabel() string {
 	return joinUnique(k.primaryNavigationLabel(ActionGoTop), k.primaryNavigationLabel(ActionGoBottom))
-}
-
-func (k KeyBindings) ReviewModeLabel() string {
-	return joinUnique(k.PrimaryLabel(ActionReviewComment), k.PrimaryLabel(ActionReviewSummary))
-}
-
-func (k KeyBindings) SaveLabel() string {
-	return k.PrimaryLabel(ActionReviewSave)
-}
-
-func (k KeyBindings) CancelLabel() string {
-	return k.PrimaryLabel(ActionCancel)
-}
-
-func (k KeyBindings) SubmitLabel() string {
-	return k.PrimaryLabel(ActionReviewSubmit)
-}
-
-func (k KeyBindings) DiscardLabel() string {
-	return k.PrimaryLabel(ActionReviewDiscard)
-}
-
-func (k KeyBindings) DiffLabel() string {
-	return k.PrimaryLabel(ActionShowDiff)
-}
-
-func (k KeyBindings) OverviewLabel() string {
-	return k.PrimaryLabel(ActionShowOverview)
-}
-
-func (k KeyBindings) RangeLabel() string {
-	return k.PrimaryLabel(ActionReviewRange)
-}
-
-func (k KeyBindings) CommentLabel() string {
-	return k.PrimaryLabel(ActionReviewComment)
-}
-
-func (k KeyBindings) SummaryLabel() string {
-	return k.PrimaryLabel(ActionReviewSummary)
-}
-
-func (k KeyBindings) HelpLabel() string {
-	return k.PrimaryLabel(ActionShowHelp)
 }
 
 func (k KeyBindings) labels(action Action) []string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -57,10 +57,14 @@ func TestKeyBindingsMatches(t *testing.T) {
 	}
 }
 
+func reviewModeLabel(keys KeyBindings) string {
+	return joinUnique(keys.PrimaryLabel(ActionReviewComment), keys.PrimaryLabel(ActionReviewSummary))
+}
+
 func TestKeyBindingsLabels(t *testing.T) {
 	keys := Default().KeyBindings
 
-	if got := keys.QuitLabel(); got != "q" {
+	if got := keys.PrimaryLabel(ActionQuit); got != "q" {
 		t.Fatalf("got %q, want %q", got, "q")
 	}
 	if got := keys.MoveLabel(); got != "j/k/↑/↓" {
@@ -72,7 +76,7 @@ func TestKeyBindingsLabels(t *testing.T) {
 	if got := keys.TopBottomLabel(); got != "g/G" {
 		t.Fatalf("got %q, want %q", got, "g/G")
 	}
-	if got := keys.ReviewModeLabel(); got != "enter/R" {
+	if got := reviewModeLabel(keys); got != "enter/R" {
 		t.Fatalf("got %q, want %q", got, "enter/R")
 	}
 }
@@ -97,7 +101,7 @@ func TestKeyBindingsLabelsFollowCustomBindings(t *testing.T) {
 	if got := keys.TopBottomLabel(); got != "g/B" {
 		t.Fatalf("got %q, want %q", got, "g/B")
 	}
-	if got := keys.ReviewModeLabel(); got != "enter/r" {
+	if got := reviewModeLabel(keys); got != "enter/r" {
 		t.Fatalf("got %q, want %q", got, "enter/r")
 	}
 }

--- a/internal/help/panel.go
+++ b/internal/help/panel.go
@@ -18,7 +18,7 @@ func RenderOverlay(background []string, sections []Section, keys config.KeyBindi
 
 func buildPanelLines(sections []Section, keys config.KeyBindings, screenWidth int) ([]string, int) {
 	content := buildContent(sections)
-	closeHint := fmt.Sprintf("Press [%s] or [%s] to close", keys.HelpLabel(), keys.Label(config.ActionCancel))
+	closeHint := fmt.Sprintf("Press [%s] or [%s] to close", keys.PrimaryLabel(config.ActionShowHelp), keys.Label(config.ActionCancel))
 
 	panelContent := make([]string, 0, len(content)+4)
 	panelContent = append(panelContent, "")

--- a/internal/help/panel_test.go
+++ b/internal/help/panel_test.go
@@ -23,8 +23,8 @@ func allSections(keys config.KeyBindings) []Section {
 // testPRSections はテスト用の最小セクション（pr/help への依存を避ける）
 func testPRSections(keys config.KeyBindings) []Section {
 	return []Section{
-		{Title: "View", Rows: [][2]string{{keys.DiffLabel(), "Show Diff"}}},
-		{Title: "Review", Rows: [][2]string{{keys.RangeLabel(), "Select Range"}}},
+		{Title: "View", Rows: [][2]string{{keys.PrimaryLabel(config.ActionShowDiff), "Show Diff"}}},
+		{Title: "Review", Rows: [][2]string{{keys.PrimaryLabel(config.ActionReviewRange), "Select Range"}}},
 	}
 }
 

--- a/internal/help/sections.go
+++ b/internal/help/sections.go
@@ -10,7 +10,7 @@ func CommonSections(keys config.KeyBindings) []Section {
 			Rows: [][2]string{
 				{keys.MoveLabel(), "Move Up/Down"},
 				{keys.PanelLabel(), "Panel Prev/Next"},
-				{keys.FocusLabel(), "Cycle Focus"},
+				{keys.PrimaryLabel(config.ActionFocusNext), "Cycle Focus"},
 				{keys.PageLabel(), "Page Up/Down"},
 				{keys.TopBottomLabel(), "Go Top/Bottom"},
 				{keys.Label(config.ActionCancel), "Cancel / Close"},

--- a/internal/pr/help/sections.go
+++ b/internal/pr/help/sections.go
@@ -11,21 +11,21 @@ func Sections(keys config.KeyBindings) []help.Section {
 		{
 			Title: "View",
 			Rows: [][2]string{
-				{keys.DiffLabel(), "Show Diff"},
-				{keys.OverviewLabel(), "Show Overview"},
-				{keys.ReloadLabel(), "Reload PR"},
-				{keys.QuitLabel(), "Quit"},
+				{keys.PrimaryLabel(config.ActionShowDiff), "Show Diff"},
+				{keys.PrimaryLabel(config.ActionShowOverview), "Show Overview"},
+				{keys.PrimaryLabel(config.ActionOpenSelected), "Reload PR"},
+				{keys.PrimaryLabel(config.ActionQuit), "Quit"},
 			},
 		},
 		{
 			Title: "Review",
 			Rows: [][2]string{
-				{keys.RangeLabel(), "Select Range"},
-				{keys.CommentLabel(), "Add Comment"},
-				{keys.SummaryLabel(), "Edit Summary"},
-				{keys.SaveLabel(), "Save Comment"},
-				{keys.SubmitLabel(), "Submit Review"},
-				{keys.DiscardLabel(), "Discard Review"},
+				{keys.PrimaryLabel(config.ActionReviewRange), "Select Range"},
+				{keys.PrimaryLabel(config.ActionReviewComment), "Add Comment"},
+				{keys.PrimaryLabel(config.ActionReviewSummary), "Edit Summary"},
+				{keys.PrimaryLabel(config.ActionReviewSave), "Save Comment"},
+				{keys.PrimaryLabel(config.ActionReviewSubmit), "Submit Review"},
+				{keys.PrimaryLabel(config.ActionReviewDiscard), "Discard Review"},
 			},
 		},
 	}

--- a/internal/pr/help/sections_test.go
+++ b/internal/pr/help/sections_test.go
@@ -13,18 +13,18 @@ func TestSections(t *testing.T) {
 	got := Sections(keys)
 	want := []ihelp.Section{
 		{Title: "View", Rows: [][2]string{
-			{keys.DiffLabel(), "Show Diff"},
-			{keys.OverviewLabel(), "Show Overview"},
-			{keys.ReloadLabel(), "Reload PR"},
-			{keys.QuitLabel(), "Quit"},
+			{keys.PrimaryLabel(config.ActionShowDiff), "Show Diff"},
+			{keys.PrimaryLabel(config.ActionShowOverview), "Show Overview"},
+			{keys.PrimaryLabel(config.ActionOpenSelected), "Reload PR"},
+			{keys.PrimaryLabel(config.ActionQuit), "Quit"},
 		}},
 		{Title: "Review", Rows: [][2]string{
-			{keys.RangeLabel(), "Select Range"},
-			{keys.CommentLabel(), "Add Comment"},
-			{keys.SummaryLabel(), "Edit Summary"},
-			{keys.SaveLabel(), "Save Comment"},
-			{keys.SubmitLabel(), "Submit Review"},
-			{keys.DiscardLabel(), "Discard Review"},
+			{keys.PrimaryLabel(config.ActionReviewRange), "Select Range"},
+			{keys.PrimaryLabel(config.ActionReviewComment), "Add Comment"},
+			{keys.PrimaryLabel(config.ActionReviewSummary), "Edit Summary"},
+			{keys.PrimaryLabel(config.ActionReviewSave), "Save Comment"},
+			{keys.PrimaryLabel(config.ActionReviewSubmit), "Submit Review"},
+			{keys.PrimaryLabel(config.ActionReviewDiscard), "Discard Review"},
 		}},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {


### PR DESCRIPTION
## Summary

- `QuitLabel`, `HelpLabel`, `SaveLabel` など14個の単純ラッパーメソッドを削除
- 呼び出し側で `PrimaryLabel(config.ActionXxx)` を直接使用するよう統一
- `PrimaryLabel` をスライス割り当てなしで実装し、ステータスライン描画（per-frame hot path）の GC 負荷を削減
- `config_test.go` に `reviewModeLabel` テストヘルパーを追加し重複を解消

## Test plan

- [x] `go fmt ./...` — 差分なし
- [x] `go vet ./...` — エラーなし
- [x] `go test ./...` — 全パッケージ green

Closes #99

https://claude.ai/code/session_0127NTVSSgRcBVbzR9vWHJYR