### PR TITLE
fix: overview モードで g/G キーが機能しない問題を修正 (#114)

### DIFF
--- a/internal/app/gui.go
+++ b/internal/app/gui.go
@@ -87,6 +87,8 @@ type DetailViewport interface {
 	Update(msg tea.KeyMsg) (bool, tea.Cmd)
 	ScrollDown(lines int)
 	ScrollUp(lines int)
+	GotoTop()
+	GotoBottom()
 	View() string
 }
 

--- a/internal/app/navigation.go
+++ b/internal/app/navigation.go
@@ -116,6 +116,10 @@ func (s *screen) handleDetailScrollAction(action config.Action) tea.Cmd {
 		}
 		_, cmd := s.gui.detail.Update(key)
 		return cmd
+	case config.ActionGoTop:
+		s.gui.detail.GotoTop()
+	case config.ActionGoBottom:
+		s.gui.detail.GotoBottom()
 	}
 	return nil
 }

--- a/pkg/gui/viewport/viewport.go
+++ b/pkg/gui/viewport/viewport.go
@@ -58,6 +58,14 @@ func (s *State) ScrollUp(lines int) {
 	s.vp.ScrollUp(lines)
 }
 
+func (s *State) GotoTop() {
+	s.vp.GotoTop()
+}
+
+func (s *State) GotoBottom() {
+	s.vp.GotoBottom()
+}
+
 func (s *State) View() string {
 	return s.vp.View()
 }


### PR DESCRIPTION
## Summary

- `handleDetailScrollAction` の overview モードに `ActionGoTop`/`ActionGoBottom` ケースを追加
- `DetailViewport` インターフェースに `GotoTop()`/`GotoBottom()` メソッドを追加
- `pkg/gui/viewport/viewport.State` に `GotoTop()`/`GotoBottom()` を実装し、bubbles viewport に委譲

## Test plan

- [ ] `go test ./...` 全テスト通過確認
- [ ] `go vet ./...` 静的解析クリア
- [ ] overview モードで `g`/`G` キーを押すと detail viewport が先頭/末尾に移動すること

Closes #114

https://claude.ai/code/session_0127NTVSSgRcBVbzR9vWHJYR