### PR TITLE
refactor: isDangerousControl の冗長な r >= 0 チェックを除去

### DIFF
--- a/internal/model/sanitize.go
+++ b/internal/model/sanitize.go
@@ -35,5 +35,5 @@ func SanitizeMultiline(s string) string {
 }
 
 func isDangerousControl(r rune) bool {
-	return (r >= 0 && r < 0x20 && r != '\n' && r != '\t') || r == 0x7f
+	return (r < 0x20 && r != '\n' && r != '\t') || r == 0x7f
 }


### PR DESCRIPTION
## Summary
- `internal/model/sanitize.go` の `isDangerousControl` から冗長な `r >= 0` チェックを除去
- Go の `range` による文字列イテレーションでは rune は常に非負のため、このチェックは常に真で意味をなさない
- 除去により読者の誤解を防ぎ、意図を明確にする

## Test plan
- [x] `go fmt ./...` 通過
- [x] `go vet ./...` 通過
- [x] `go test ./...` 全パッケージ通過

Closes #113

https://claude.ai/code/session_0127NTVSSgRcBVbzR9vWHJYR