### PR TITLE
refactor: review/state.go の ResetAfterSubmit/ResetAfterDiscard の重複解消

### DIFF
--- a/internal/review/state.go
+++ b/internal/review/state.go
@@ -175,11 +175,14 @@ func (rs *ReviewState) ClearRangeStart() {
 }
 
 func (rs *ReviewState) ResetAfterSubmit(notice string) {
-	rs.reset()
-	rs.Notice = model.SanitizeMultiline(notice)
+	rs.resetWithNotice(notice)
 }
 
 func (rs *ReviewState) ResetAfterDiscard(notice string) {
+	rs.resetWithNotice(notice)
+}
+
+func (rs *ReviewState) resetWithNotice(notice string) {
 	rs.reset()
 	rs.Notice = model.SanitizeMultiline(notice)
 }


### PR DESCRIPTION
## Summary
- `ResetAfterSubmit` と `ResetAfterDiscard` の同一実装を `resetWithNotice` に抽出
- 両 public メソッドから委譲することで、guard ロジックの変更が1箇所で済むように改善

## Test plan
- [x] `go fmt ./...` 通過
- [x] `go vet ./...` 通過
- [x] `go test ./...` 全パッケージ通過

Closes #110

https://claude.ai/code/session_0127NTVSSgRcBVbzR9vWHJYR