### PR TITLE
refactor: navigateDown/navigateUp の guard ロジック重複を解消する

### DIFF
--- a/internal/app/navigate.go
+++ b/internal/app/navigate.go
@@ -2,22 +2,18 @@ package app
 
 const pendingReviewBlockNotice = "Pending review exists. Submit with S or discard with X."
 
-// navigateDown moves selection down, blocking if a pending review exists for
-// the current PR. Returns true if the selection changed.
-func (gui *Gui) navigateDown() bool {
+func (gui *Gui) navigate(fn func() bool) bool {
 	if gui.coord.BlocksPRSelectionChange() {
 		gui.review.SetNotice(pendingReviewBlockNotice)
 		return false
 	}
-	return gui.coord.NavigateDown()
+	return fn()
 }
+
+// navigateDown moves selection down, blocking if a pending review exists for
+// the current PR. Returns true if the selection changed.
+func (gui *Gui) navigateDown() bool { return gui.navigate(gui.coord.NavigateDown) }
 
 // navigateUp moves selection up, blocking if a pending review exists for the
 // current PR. Returns true if the selection changed.
-func (gui *Gui) navigateUp() bool {
-	if gui.coord.BlocksPRSelectionChange() {
-		gui.review.SetNotice(pendingReviewBlockNotice)
-		return false
-	}
-	return gui.coord.NavigateUp()
-}
+func (gui *Gui) navigateUp() bool { return gui.navigate(gui.coord.NavigateUp) }


### PR DESCRIPTION
## Summary

- `navigateDown` と `navigateUp` に共通していた `BlocksPRSelectionChange` ガードロジックを `navigate` ヘルパーに抽出
- 重複コードを除去し、変更の影響範囲を一箇所に集約

## Test plan

- [ ] `go test ./...` が通ること
- [ ] `navigateDown`/`navigateUp` の既存テストがパスすること

https://claude.ai/code/session_01PfsQ5LeXv28cxsq1h5uiUz