### PR TITLE
fix: AddReviewComment がコメント未作成時に無音でエラーを隠す問題を修正

### DIFF
--- a/internal/gh/review_client.go
+++ b/internal/gh/review_client.go
@@ -135,7 +135,7 @@ func (c *Client) AddReviewComment(_ string, reviewID string, comment ReviewComme
 	}
 	nodes := resp.Data.AddPullRequestReviewThread.Thread.Comments.Nodes
 	if len(nodes) == 0 {
-		return "", nil
+		return "", fmt.Errorf("comment node is empty")
 	}
 	return strings.TrimSpace(nodes[0].ID), nil
 }


### PR DESCRIPTION
## Summary

- `AddReviewComment` で GraphQL レスポンスにコメントノードが含まれない場合に `("", nil)` を返していた
- 呼び出し元がエラーを検知できずサイレントに失敗していた
- `fmt.Errorf("comment node is empty")` を返すよう修正し、既存のエラーメッセージスタイルと統一

## Test plan

- [x] `go fmt ./...` 通過
- [x] `go vet ./...` 通過
- [x] `go test ./...` 全パッケージ通過

Closes #121

https://claude.ai/code/session_0127NTVSSgRcBVbzR9vWHJYR