### PR TITLE
refactor(review): Reader/Handler縮小とHandleCancel導入でControllerの公開API削減

### DIFF
--- a/internal/app/input.go
+++ b/internal/app/input.go
@@ -6,7 +6,6 @@ import (
 	"github.com/rin2yh/lazygh/internal/config"
 	"github.com/rin2yh/lazygh/internal/pr/list"
 	"github.com/rin2yh/lazygh/internal/pr/overview"
-	"github.com/rin2yh/lazygh/internal/pr/review"
 )
 
 // --- メインキー入力ディスパッチャ ---
@@ -60,14 +59,10 @@ func (s *screen) handleGlobalAction(action config.Action) (tea.Cmd, bool) {
 }
 
 func (s *screen) handleCancel() tea.Cmd {
-	if s.gui.review.InputMode() == review.InputNone && s.gui.review.HasRangeStart() {
-		s.gui.review.ClearRangeStart()
-		s.gui.review.Notify("Range selection cleared.")
-		s.gui.focus = layout.FocusDiffContent
+	if s.gui.review.HandleCancel() {
 		return nil
 	}
 	if s.gui.focus == layout.FocusReviewDrawer {
-		s.gui.review.StopInput()
 		s.gui.focus = layout.FocusDiffContent
 		return nil
 	}

--- a/internal/pr/review/comment_test.go
+++ b/internal/pr/review/comment_test.go
@@ -146,7 +146,7 @@ func TestHandleEditorKey_EscCancelsCommentAndClearsRange(t *testing.T) {
 	c.setFocus = func(target FocusTarget) { focus = target }
 	c.SetCommentValue("draft")
 
-	_, handled := c.EditorKey(tea.KeyMsg{Type: tea.KeyEsc})
+	_, handled := c.editorKey(tea.KeyMsg{Type: tea.KeyEsc})
 	if !handled {
 		t.Fatal("expected key handled")
 	}

--- a/internal/pr/review/controller.go
+++ b/internal/pr/review/controller.go
@@ -43,238 +43,15 @@ func NewController(cfg *config.Config, app AppState, client PendingReviewClient,
 	}
 }
 
-// --- state accessors for the gui layer ---
+// --- Reader interface ---
 
-func (c *Controller) InputMode() InputMode    { return c.rs.InputMode }
-func (c *Controller) Summary() string         { return c.rs.Summary }
-func (c *Controller) EventLabel() string      { return c.rs.Event.Label() }
-func (c *Controller) Notice() string          { return c.rs.Notice }
-func (c *Controller) RangeStart() *Range      { return c.rs.RangeStart }
-func (c *Controller) Comments() []Comment     { return c.rs.Comments }
-func (c *Controller) SelectedCommentIdx() int { return c.rs.SelectedCommentIdx }
-func (c *Controller) HasRangeStart() bool     { return c.rs.RangeStart != nil }
-func (c *Controller) IsInInputMode() bool     { return c.rs.InputMode != InputNone }
-func (c *Controller) HasPendingReview() bool  { return c.rs.HasPendingReview() }
-func (c *Controller) PRNumber() int           { return c.rs.PRNumber }
-func (c *Controller) Notify(msg string)       { c.rs.Notify(msg) }
-func (c *Controller) ClearRangeStart()        { c.rs.ClearRangeStart() }
-
-// Reset clears review state (called when the PR list reloads).
-func (c *Controller) Reset() { c.rs.Reset() }
-
-// SetContext sets the pending review context (PR number, IDs).
-func (c *Controller) SetContext(prNumber int, pullRequestID, commitOID, reviewID string) {
-	c.rs.SetContext(prNumber, pullRequestID, commitOID, reviewID)
-}
-
-// OpenDrawer opens the review drawer.
-func (c *Controller) OpenDrawer() { c.rs.OpenDrawer() }
-
-// BeginCommentInput puts the drawer into comment input mode.
-func (c *Controller) BeginCommentInput() { c.rs.BeginCommentInput() }
-
-// --- view ---
-
-func (c *Controller) ShouldShowDrawer() bool {
-	return c.view.ShouldShowDrawer()
-}
-
-// --- comment editor ---
-
-func (c *Controller) CommentValue() string {
-	return c.comment.CurrentValue()
-}
-
-func (c *Controller) SetCommentValue(value string) {
-	c.comment.SetValue(value)
-}
-
-func (c *Controller) SummaryValue() string {
-	return c.summary.Text()
-}
-
-func (c *Controller) CommentInputLines() []string {
-	return c.comment.InputLines()
-}
-
-func (c *Controller) SummaryInputLines() []string {
-	return c.summary.Lines()
-}
-
-func (c *Controller) BeginSummaryInput() {
-	c.summary.BeginInput()
-	c.setFocus(FocusReviewDrawer)
-}
-
-func (c *Controller) StopInput() {
-	if t, ok := c.view.StopInput(); ok {
-		c.setFocus(t)
-	}
-}
-
-func (c *Controller) ClearCommentInput() {
-	c.comment.Clear()
-}
-
-func (c *Controller) EditorKey(msg tea.KeyMsg) (tea.Cmd, bool) {
-	switch msg.Type {
-	case tea.KeyEsc:
-		handled := c.view.HandleEsc()
-		if handled {
-			c.setFocus(FocusDiffContent)
-		}
-		return nil, handled
-	}
-	if c.keys.Matches(msg, config.ActionReviewSave) && c.view.InputMode() == InputSummary {
-		if t, ok := c.view.HandleSummarySave(); ok {
-			c.setFocus(t)
-		}
-		return nil, true
-	}
-
-	switch c.view.InputMode() {
-	case InputComment:
-		return c.comment.HandleKey(msg)
-	case InputSummary:
-		return c.summary.HandleKey(msg)
-	default:
-		return nil, false
-	}
-}
-
-// --- range ---
-
-func (c *Controller) ToggleRangeSelection() {
-	if c.rng.ToggleSelection() {
-		c.setFocus(FocusDiffContent)
-	}
-}
+func (c *Controller) InputMode() InputMode   { return c.rs.InputMode }
+func (c *Controller) IsInInputMode() bool    { return c.rs.InputMode != InputNone }
+func (c *Controller) RangeStart() *Range     { return c.rs.RangeStart }
+func (c *Controller) ShouldShowDrawer() bool { return c.view.ShouldShowDrawer() }
 
 func (c *Controller) IsIndexWithinPendingRange(path string, commentable bool, idx int) bool {
 	return c.rng.IsIndexWithinPendingRange(path, commentable, idx)
-}
-
-// --- pending review actions ---
-
-func (c *Controller) BuildCommentDraft(body string) (gh.ReviewComment, error) {
-	return c.comment.BuildDraft(body, c.rng.RangeStart())
-}
-
-func (c *Controller) SaveComment() tea.Cmd {
-	return c.pending.HandleCommentSave()
-}
-
-func (c *Controller) Submit() tea.Cmd {
-	return c.pending.HandleSubmit()
-}
-
-func (c *Controller) Discard() tea.Cmd {
-	return c.pending.HandleDiscard()
-}
-
-func (c *Controller) CommentResult(msg CommentSavedMsg) {
-	if c.pending.ApplyCommentResult(msg) {
-		c.setFocus(FocusReviewDrawer)
-	}
-}
-
-func (c *Controller) SubmitResult(msg SubmittedMsg) {
-	c.pending.ApplySubmitResult(msg)
-	if msg.Err == nil {
-		c.setFocus(FocusDiffContent)
-	}
-}
-
-func (c *Controller) DiscardResult(msg DiscardedMsg) {
-	c.pending.ApplyDiscardResult(msg)
-	if msg.Err == nil {
-		c.setFocus(FocusDiffContent)
-	}
-}
-
-func (c *Controller) DeleteComment() tea.Cmd {
-	return c.pending.HandleDeleteComment()
-}
-
-func (c *Controller) EditComment() bool {
-	if !c.pending.BeginEditComment() {
-		return false
-	}
-	c.setFocus(FocusDiffContent)
-	return true
-}
-
-func (c *Controller) SaveEditComment() tea.Cmd {
-	return c.pending.HandleEditCommentSave()
-}
-
-func (c *Controller) DeleteCommentResult(msg CommentDeletedMsg) {
-	c.pending.ApplyDeleteCommentResult(msg)
-}
-
-func (c *Controller) EditCommentResult(msg CommentUpdatedMsg) {
-	c.pending.ApplyEditCommentResult(msg)
-	if msg.Err == nil {
-		c.setFocus(FocusReviewDrawer)
-	}
-}
-
-func (c *Controller) SelectNextComment() {
-	c.pending.SelectNextComment()
-}
-
-func (c *Controller) SelectPrevComment() {
-	c.pending.SelectPrevComment()
-}
-
-func (c *Controller) IsEditingComment() bool {
-	return c.pending.IsEditingComment()
-}
-
-func (c *Controller) CycleReviewEvent() {
-	c.rs.CycleEvent()
-}
-
-// MarkStaleComments marks pending comments whose anchor position no longer
-// exists in files as stale. Call this whenever the diff is refreshed.
-func (c *Controller) MarkStaleComments(files []gh.DiffFile) {
-	if len(c.rs.Comments) == 0 || len(files) == 0 {
-		return
-	}
-	type pos struct {
-		side gh.DiffSide
-		line int
-	}
-	valid := make(map[string]map[pos]bool, len(files))
-	for _, file := range files {
-		m := make(map[pos]bool)
-		for _, l := range file.Lines {
-			if !l.Commentable {
-				continue
-			}
-			if l.NewLine > 0 {
-				m[pos{gh.DiffSideRight, l.NewLine}] = true
-			}
-			if l.OldLine > 0 {
-				m[pos{gh.DiffSideLeft, l.OldLine}] = true
-			}
-		}
-		valid[file.Path] = m
-	}
-	for i := range c.rs.Comments {
-		comment := &c.rs.Comments[i]
-		m, ok := valid[comment.Path]
-		if !ok {
-			comment.Stale = true
-			continue
-		}
-		comment.Stale = !m[pos{gh.DiffSide(comment.Side), comment.Line}]
-	}
-}
-
-func (c *Controller) BeginCommentFlow() {
-	c.comment.BeginInput()
-	c.setFocus(FocusReviewDrawer)
 }
 
 // BuildDrawerInput assembles an Input from the current review state.
@@ -320,24 +97,53 @@ func (c *Controller) BuildDrawerInput(showDrawer bool) *Input {
 	return input
 }
 
+// --- ReviewHook (coordinator.ReviewHook) ---
+
+func (c *Controller) HasPendingReview() bool { return c.rs.HasPendingReview() }
+func (c *Controller) PRNumber() int          { return c.rs.PRNumber }
+func (c *Controller) Reset()                 { c.rs.Reset() }
+
+// --- Handler interface ---
+
+// Notify shows a notice message in the review drawer.
+func (c *Controller) Notify(msg string) { c.rs.Notify(msg) }
+
+// HandleCancel handles review-specific cancel logic, returning true if consumed.
+// Clears an active range selection or stops an active input mode.
+// Focus is moved to FocusDiffContent via the injected setFocus callback.
+func (c *Controller) HandleCancel() bool {
+	if c.rs.InputMode == InputNone && c.rs.RangeStart != nil {
+		c.rs.ClearRangeStart()
+		c.rs.Notify("Range selection cleared.")
+		c.setFocus(FocusDiffContent)
+		return true
+	}
+	if c.rs.InputMode != InputNone {
+		c.view.StopInput()
+		c.setFocus(FocusDiffContent)
+		return true
+	}
+	return false
+}
+
 func (c *Controller) HandleInputKey(msg tea.KeyMsg) (tea.Cmd, bool) {
 	action, ok := c.keys.ActionFor(msg)
 	if ok {
 		switch action {
 		case config.ActionReviewSubmit:
-			return c.Submit(), true
+			return c.pending.HandleSubmit(), true
 		case config.ActionReviewDiscard:
-			return c.Discard(), true
+			return c.pending.HandleDiscard(), true
 		case config.ActionReviewSave:
 			if c.rs.InputMode == InputComment {
-				if c.IsEditingComment() {
-					return c.SaveEditComment(), true
+				if c.pending.IsEditingComment() {
+					return c.pending.HandleEditCommentSave(), true
 				}
-				return c.SaveComment(), true
+				return c.pending.HandleCommentSave(), true
 			}
 		}
 	}
-	if cmd, handled := c.EditorKey(msg); handled {
+	if cmd, handled := c.editorKey(msg); handled {
 		return cmd, true
 	}
 	return nil, false
@@ -346,34 +152,182 @@ func (c *Controller) HandleInputKey(msg tea.KeyMsg) (tea.Cmd, bool) {
 func (c *Controller) HandleAction(action config.Action) tea.Cmd {
 	switch action {
 	case config.ActionReviewRange:
-		return c.requireDiffMode("Review range selection is only available in diff view.", c.ToggleRangeSelection)
+		return c.requireDiffMode("Review range selection is only available in diff view.", c.toggleRangeSelection)
 	case config.ActionReviewComment:
-		return c.requireDiffMode("Review comments are only available in diff view.", c.BeginCommentFlow)
+		return c.requireDiffMode("Review comments are only available in diff view.", c.beginCommentFlow)
 	case config.ActionReviewSummary:
-		return c.requireDiffMode("Review summary is only available in diff view.", c.BeginSummaryInput)
+		return c.requireDiffMode("Review summary is only available in diff view.", c.beginSummaryInput)
 	case config.ActionReviewSubmit:
-		return c.Submit()
+		return c.pending.HandleSubmit()
 	case config.ActionReviewDiscard:
-		return c.Discard()
+		return c.pending.HandleDiscard()
 	case config.ActionReviewClearComment:
 		if c.rs.InputMode == InputComment {
-			c.ClearCommentInput()
+			c.comment.Clear()
 		}
 	case config.ActionReviewEvent:
 		if c.isDiffMode() {
-			c.CycleReviewEvent()
+			c.rs.CycleEvent()
 		}
 	case config.ActionReviewDeleteComment:
-		return c.DeleteComment()
+		return c.pending.HandleDeleteComment()
 	case config.ActionReviewEditComment:
-		c.EditComment()
+		c.editComment()
 	}
 	return nil
 }
 
+func (c *Controller) SelectNextComment() { c.pending.SelectNextComment() }
+func (c *Controller) SelectPrevComment() { c.pending.SelectPrevComment() }
+
+// --- Applier interface ---
+
+func (c *Controller) CommentResult(msg CommentSavedMsg) {
+	if c.pending.ApplyCommentResult(msg) {
+		c.setFocus(FocusReviewDrawer)
+	}
+}
+
+func (c *Controller) SubmitResult(msg SubmittedMsg) {
+	c.pending.ApplySubmitResult(msg)
+	if msg.Err == nil {
+		c.setFocus(FocusDiffContent)
+	}
+}
+
+func (c *Controller) DiscardResult(msg DiscardedMsg) {
+	c.pending.ApplyDiscardResult(msg)
+	if msg.Err == nil {
+		c.setFocus(FocusDiffContent)
+	}
+}
+
+func (c *Controller) DeleteCommentResult(msg CommentDeletedMsg) {
+	c.pending.ApplyDeleteCommentResult(msg)
+}
+
+func (c *Controller) EditCommentResult(msg CommentUpdatedMsg) {
+	c.pending.ApplyEditCommentResult(msg)
+	if msg.Err == nil {
+		c.setFocus(FocusReviewDrawer)
+	}
+}
+
+// MarkStaleComments marks pending comments whose anchor position no longer
+// exists in files as stale. Call this whenever the diff is refreshed.
+func (c *Controller) MarkStaleComments(files []gh.DiffFile) {
+	if len(c.rs.Comments) == 0 || len(files) == 0 {
+		return
+	}
+	type pos struct {
+		side gh.DiffSide
+		line int
+	}
+	valid := make(map[string]map[pos]bool, len(files))
+	for _, file := range files {
+		m := make(map[pos]bool)
+		for _, l := range file.Lines {
+			if !l.Commentable {
+				continue
+			}
+			if l.NewLine > 0 {
+				m[pos{gh.DiffSideRight, l.NewLine}] = true
+			}
+			if l.OldLine > 0 {
+				m[pos{gh.DiffSideLeft, l.OldLine}] = true
+			}
+		}
+		valid[file.Path] = m
+	}
+	for i := range c.rs.Comments {
+		comment := &c.rs.Comments[i]
+		m, ok := valid[comment.Path]
+		if !ok {
+			comment.Stale = true
+			continue
+		}
+		comment.Stale = !m[pos{gh.DiffSide(comment.Side), comment.Line}]
+	}
+}
+
+// --- Lifecycle (not in interfaces; accessed via concrete type in tests) ---
+
+// SetContext sets the pending review context (PR number, IDs).
+func (c *Controller) SetContext(prNumber int, pullRequestID, commitOID, reviewID string) {
+	c.rs.SetContext(prNumber, pullRequestID, commitOID, reviewID)
+}
+
+// OpenDrawer opens the review drawer.
+func (c *Controller) OpenDrawer() { c.rs.OpenDrawer() }
+
+// BeginCommentInput puts the drawer into comment input mode.
+func (c *Controller) BeginCommentInput() { c.rs.BeginCommentInput() }
+
+// --- Test support (not in interfaces) ---
+
+func (c *Controller) CommentValue() string         { return c.comment.CurrentValue() }
+func (c *Controller) SetCommentValue(value string) { c.comment.SetValue(value) }
+func (c *Controller) SummaryValue() string         { return c.summary.Text() }
+
+// --- internal ---
+
+func (c *Controller) editorKey(msg tea.KeyMsg) (tea.Cmd, bool) {
+	switch msg.Type {
+	case tea.KeyEsc:
+		handled := c.view.HandleEsc()
+		if handled {
+			c.setFocus(FocusDiffContent)
+		}
+		return nil, handled
+	}
+	if c.keys.Matches(msg, config.ActionReviewSave) && c.view.InputMode() == InputSummary {
+		if t, ok := c.view.HandleSummarySave(); ok {
+			c.setFocus(t)
+		}
+		return nil, true
+	}
+
+	switch c.view.InputMode() {
+	case InputComment:
+		return c.comment.HandleKey(msg)
+	case InputSummary:
+		return c.summary.HandleKey(msg)
+	default:
+		return nil, false
+	}
+}
+
+func (c *Controller) toggleRangeSelection() {
+	if c.rng.ToggleSelection() {
+		c.setFocus(FocusDiffContent)
+	}
+}
+
+func (c *Controller) beginCommentFlow() {
+	c.comment.BeginInput()
+	c.setFocus(FocusReviewDrawer)
+}
+
+func (c *Controller) beginSummaryInput() {
+	c.summary.BeginInput()
+	c.setFocus(FocusReviewDrawer)
+}
+
+func (c *Controller) editComment() bool {
+	if !c.pending.BeginEditComment() {
+		return false
+	}
+	c.setFocus(FocusDiffContent)
+	return true
+}
+
+// saveComment and submit are unexported but called directly from tests.
+func (c *Controller) saveComment() tea.Cmd { return c.pending.HandleCommentSave() }
+func (c *Controller) submit() tea.Cmd      { return c.pending.HandleSubmit() }
+
 func (c *Controller) requireDiffMode(notice string, fn func()) tea.Cmd {
 	if !c.isDiffMode() {
-		c.Notify(notice)
+		c.rs.Notify(notice)
 		return nil
 	}
 	fn()

--- a/internal/pr/review/controller.go
+++ b/internal/pr/review/controller.go
@@ -321,7 +321,6 @@ func (c *Controller) editComment() bool {
 	return true
 }
 
-// saveComment and submit are unexported but called directly from tests.
 func (c *Controller) saveComment() tea.Cmd { return c.pending.HandleCommentSave() }
 func (c *Controller) submit() tea.Cmd      { return c.pending.HandleSubmit() }
 

--- a/internal/pr/review/controller_test.go
+++ b/internal/pr/review/controller_test.go
@@ -48,7 +48,7 @@ func TestHandleCommentSave_NoPRSelected(t *testing.T) {
 	host := &fakeHost{}
 	c := NewController(defaultTestConfig(), host, &testmock.GHClient{}, reviewstub.Selection{}, func(FocusTarget) {})
 
-	cmd := c.SaveComment()
+	cmd := c.saveComment()
 	if cmd != nil {
 		t.Fatal("expected nil cmd when no PR selected")
 	}
@@ -64,7 +64,7 @@ func TestHandleCommentSave_BuildDraftError(t *testing.T) {
 	c, _, _ := setupControllerWithPR(&testmock.GHClient{}, sel)
 	c.SetCommentValue("")
 
-	cmd := c.SaveComment()
+	cmd := c.saveComment()
 	if cmd != nil {
 		t.Fatal("expected nil cmd on draft error")
 	}
@@ -80,7 +80,7 @@ func TestHandleCommentSave_InvalidLine(t *testing.T) {
 	c, _, _ := setupControllerWithPR(&testmock.GHClient{}, sel)
 	c.SetCommentValue("hello")
 
-	cmd := c.SaveComment()
+	cmd := c.saveComment()
 	if cmd != nil {
 		t.Fatal("expected nil cmd on non-commentable line")
 	}
@@ -93,7 +93,7 @@ func TestHandleSubmit_NoPendingReview(t *testing.T) {
 	host := &fakeHost{}
 	c := NewController(defaultTestConfig(), host, &testmock.GHClient{}, reviewstub.Selection{}, func(FocusTarget) {})
 
-	cmd := c.Submit()
+	cmd := c.submit()
 	if cmd != nil {
 		t.Fatal("expected nil cmd when no pending review")
 	}
@@ -205,7 +205,7 @@ func TestHandleSubmit_SavesSummaryIfInSummaryMode(t *testing.T) {
 
 	c.summary.Load("my summary text")
 
-	cmd := c.Submit()
+	cmd := c.submit()
 	if cmd == nil {
 		t.Fatal("expected non-nil cmd for submit")
 	}

--- a/internal/pr/review/interfaces.go
+++ b/internal/pr/review/interfaces.go
@@ -43,49 +43,27 @@ type PendingReviewClient interface {
 	UpdatePendingReviewComment(commentID string, body string) error
 }
 
-// Reader はレビュー状態の読み取り専用インターフェース。ISP に従い Handler / Applier と分離している。
+// Reader はGUIレイヤーが参照するレビュー状態の読み取りインターフェース。
+// BuildDrawerInput が描画用DTOを一括提供するため、個々の状態フィールドは含めない。
 type Reader interface {
 	ShouldShowDrawer() bool
 	IsIndexWithinPendingRange(path string, commentable bool, idx int) bool
-	SummaryValue() string
-	CommentInputLines() []string
-	SummaryInputLines() []string
-	IsEditingComment() bool
 	InputMode() InputMode
-	Summary() string
-	EventLabel() string
-	Notice() string
-	RangeStart() *Range
-	Comments() []Comment
-	SelectedCommentIdx() int
-	HasRangeStart() bool
 	IsInInputMode() bool
-	HasPendingReview() bool
-	PRNumber() int
+	RangeStart() *Range
 	BuildDrawerInput(showDrawer bool) *Input
 }
 
 // Handler はユーザー入力によるレビュー操作を処理する。
 type Handler interface {
-	EditorKey(msg tea.KeyMsg) (tea.Cmd, bool)
 	HandleInputKey(msg tea.KeyMsg) (tea.Cmd, bool)
 	HandleAction(action config.Action) tea.Cmd
-	Submit() tea.Cmd
-	Discard() tea.Cmd
-	SaveComment() tea.Cmd
-	SaveEditComment() tea.Cmd
-	DeleteComment() tea.Cmd
-	StopInput()
-	ClearCommentInput()
-	CycleReviewEvent()
-	EditComment() bool
+	// HandleCancel はレビュー固有のキャンセル処理を行う。
+	// range選択中またはinput mode中であれば処理してtrueを返す。
+	HandleCancel() bool
 	SelectNextComment()
 	SelectPrevComment()
-	ToggleRangeSelection()
-	BeginCommentFlow()
-	BeginSummaryInput()
 	Notify(msg string)
-	ClearRangeStart()
 }
 
 // Applier は外部から得た結果をレビュー状態に適用する。

--- a/internal/pr/review/pending_test.go
+++ b/internal/pr/review/pending_test.go
@@ -58,7 +58,7 @@ func TestHandleDeleteComment_WithCommentID(t *testing.T) {
 	c.rs.AddComment(Comment{CommentID: "IC_1", Path: "a.go", Body: "hi", Line: 1})
 	c.rs.SelectedCommentIdx = 0
 
-	cmd := c.DeleteComment()
+	cmd := c.pending.HandleDeleteComment()
 	if cmd == nil {
 		t.Fatal("expected non-nil cmd")
 	}

--- a/internal/pr/review/range_test.go
+++ b/internal/pr/review/range_test.go
@@ -25,7 +25,7 @@ func TestToggleRangeSelection_StartsAndClearsRange(t *testing.T) {
 		focus = target
 	})
 
-	controller.ToggleRangeSelection()
+	controller.toggleRangeSelection()
 	if controller.rs.RangeStart == nil {
 		t.Fatal("expected range start")
 	}
@@ -36,7 +36,7 @@ func TestToggleRangeSelection_StartsAndClearsRange(t *testing.T) {
 		t.Fatalf("got %v, want %v", focus, FocusDiffContent)
 	}
 
-	controller.ToggleRangeSelection()
+	controller.toggleRangeSelection()
 	if controller.rs.RangeStart != nil {
 		t.Fatal("expected range selection cleared")
 	}


### PR DESCRIPTION
- Reader interface: 18→6メソッド（BuildDrawerInputが状態を一括提供するため個別accessor不要）
- Handler interface: 19→6メソッド（HandleAction/HandleInputKey経由のみのメソッドを非公開化）
- HandleCancel()を新設し、input.goからのClearRangeStart/Notify/StopInput直接呼び出しを排除
- handleCancel()がreviewの内部状態を知る必要がなくなりinput.goのreviewインポートも削除
- SaveComment/Submit/EditorKey/ToggleRangeSelection等を非公開化（テストは同一パッケージから継続アクセス）

Controller公開メソッド数: 約50→約27

https://claude.ai/code/session_01EJTuayhEUujvvJpgz2DHtT