### PR TITLE
feat: 既存 review thread の表示と返信機能を追加

### DIFF
--- a/internal/app/fetch.go
+++ b/internal/app/fetch.go
@@ -3,10 +3,12 @@ package app
 import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/rin2yh/lazygh/internal/app/layout"
+	"github.com/rin2yh/lazygh/internal/gh"
 	"github.com/rin2yh/lazygh/internal/pr"
 	"github.com/rin2yh/lazygh/internal/pr/diff"
 	"github.com/rin2yh/lazygh/internal/pr/list"
 	"github.com/rin2yh/lazygh/internal/pr/overview"
+	"github.com/rin2yh/lazygh/internal/pr/review"
 )
 
 type prsLoadedMsg struct {
@@ -20,6 +22,12 @@ type detailLoadedMsg struct {
 	number  int
 	content string
 	err     error
+}
+
+type threadsLoadedMsg struct {
+	prNumber int
+	threads  []gh.ReviewThread
+	err      error
 }
 
 func (s *screen) loadPRsCmd() tea.Cmd {
@@ -53,26 +61,49 @@ func (s *screen) loadDetailCmd(repo string, number int, mode overview.DetailMode
 	}
 }
 
+func (s *screen) loadThreadsCmd(repo string, number int) tea.Cmd {
+	tc := s.gui.threadClient
+	if tc == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		threads, err := tc.GetReviewThreads(repo, number)
+		return threadsLoadedMsg{prNumber: number, threads: threads, err: err}
+	}
+}
+
+func (gui *Gui) applyThreadsResult(msg threadsLoadedMsg) {
+	item, ok := gui.coord.SelectedPR()
+	if !ok || item.Number != msg.prNumber {
+		return
+	}
+	gui.review.ThreadsResult(review.ThreadsLoadedMsg{
+		Threads: msg.threads,
+		Err:     msg.err,
+	})
+}
+
 func (gui *Gui) applyPRsResult(msg prsLoadedMsg) {
 	gui.coord.ApplyPRsResult(msg.repo, msg.prs, msg.err)
 	gui.focus = layout.FocusPRs
 }
 
-func (gui *Gui) applyDetailResult(msg detailLoadedMsg) {
+func (gui *Gui) applyDetailResult(msg detailLoadedMsg) tea.Cmd {
 	if !gui.coord.ShouldApplyDetailResult(msg.mode, msg.number) {
-		return
+		return nil
 	}
 	if msg.mode == overview.DetailModeDiff {
 		gui.coord.ApplyDiffResult(msg.content, msg.err)
 		if msg.err != nil {
 			gui.diff.Reset()
 			gui.resetDiffFocusIfOnFiles()
-			return
+			return nil
 		}
 		gui.updateDiffFiles(gui.coord.Overview.Content())
-		return
+		return nil
 	}
 	gui.coord.ApplyDetailResult(msg.content, msg.err)
+	return nil
 }
 
 func (gui *Gui) currentDiffContent() string {

--- a/internal/app/fetch_test.go
+++ b/internal/app/fetch_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestModelInitLoadsPRs(t *testing.T) {
 	mc := &testmock.GHClient{Repo: "owner/repo", PRs: []gh.PRItem{testfactory.NewGHPRItem(2, "p")}}
-	g, err := NewGui(config.Default(), NewCoordinator(), mc, mc)
+	g, err := NewGui(config.Default(), NewCoordinator(), mc, mc, mc)
 	if err != nil {
 		t.Fatalf("NewGui failed: %v", err)
 	}
@@ -70,7 +70,7 @@ func TestScreenOpenSelectedPR(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g, err := NewGui(config.Default(), NewCoordinator(), tt.client, tt.client)
+			g, err := NewGui(config.Default(), NewCoordinator(), tt.client, tt.client, nil)
 			if err != nil {
 				t.Fatalf("NewGui failed: %v", err)
 			}
@@ -151,7 +151,7 @@ func TestGuiApplyPRsResult(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g, err := NewGui(config.Default(), NewCoordinator(), &testmock.GHClient{}, &testmock.GHClient{})
+			g, err := NewGui(config.Default(), NewCoordinator(), &testmock.GHClient{}, &testmock.GHClient{}, nil)
 			if err != nil {
 				t.Fatalf("NewGui failed: %v", err)
 			}
@@ -214,7 +214,7 @@ func TestGuiApplyDetailResult(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g, err := NewGui(config.Default(), NewCoordinator(), &testmock.GHClient{}, &testmock.GHClient{})
+			g, err := NewGui(config.Default(), NewCoordinator(), &testmock.GHClient{}, &testmock.GHClient{}, nil)
 			if err != nil {
 				t.Fatalf("NewGui failed: %v", err)
 			}
@@ -234,7 +234,7 @@ func TestGuiApplyDetailResult(t *testing.T) {
 }
 
 func TestApplyDetailResult_DiffUsesSanitizedContent(t *testing.T) {
-	g, err := NewGui(config.Default(), NewCoordinator(), &testmock.GHClient{}, &testmock.GHClient{})
+	g, err := NewGui(config.Default(), NewCoordinator(), &testmock.GHClient{}, &testmock.GHClient{}, nil)
 	if err != nil {
 		t.Fatalf("NewGui failed: %v", err)
 	}
@@ -272,7 +272,7 @@ func TestApplyDetailResult_DiffUsesSanitizedContent(t *testing.T) {
 }
 
 func TestUpdateDiffFiles(t *testing.T) {
-	g, err := NewGui(config.Default(), NewCoordinator(), &testmock.GHClient{}, &testmock.GHClient{})
+	g, err := NewGui(config.Default(), NewCoordinator(), &testmock.GHClient{}, &testmock.GHClient{}, nil)
 	if err != nil {
 		t.Fatalf("NewGui failed: %v", err)
 	}

--- a/internal/app/focus_test.go
+++ b/internal/app/focus_test.go
@@ -29,7 +29,7 @@ func TestNavigatePRList(t *testing.T) {
 }
 
 func TestCycleFocus_DiffMode(t *testing.T) {
-	g, err := NewGui(config.Default(), NewCoordinator(), &testmock.GHClient{}, &testmock.GHClient{})
+	g, err := NewGui(config.Default(), NewCoordinator(), &testmock.GHClient{}, &testmock.GHClient{}, nil)
 	if err != nil {
 		t.Fatalf("NewGui failed: %v", err)
 	}
@@ -148,7 +148,7 @@ func TestModelUpdateFocusKeysInDiffMode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g, err := NewGui(config.Default(), NewCoordinator(), &testmock.GHClient{}, &testmock.GHClient{})
+			g, err := NewGui(config.Default(), NewCoordinator(), &testmock.GHClient{}, &testmock.GHClient{}, nil)
 			if err != nil {
 				t.Fatalf("NewGui failed: %v", err)
 			}
@@ -217,7 +217,7 @@ func TestModelUpdateFocusKeysInOverviewMode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g, err := NewGui(config.Default(), NewCoordinator(), &testmock.GHClient{}, &testmock.GHClient{})
+			g, err := NewGui(config.Default(), NewCoordinator(), &testmock.GHClient{}, &testmock.GHClient{}, nil)
 			if err != nil {
 				t.Fatalf("NewGui failed: %v", err)
 			}

--- a/internal/app/gui.go
+++ b/internal/app/gui.go
@@ -24,9 +24,10 @@ type reviewController interface {
 }
 
 type Gui struct {
-	config *config.Config
-	coord  *Coordinator
-	client prClient
+	config       *config.Config
+	coord        *Coordinator
+	client       prClient
+	threadClient review.ThreadClient
 
 	focus    layout.Focus
 	showHelp bool
@@ -37,16 +38,18 @@ type Gui struct {
 	review reviewController
 }
 
-func NewGui(cfg *config.Config, coord *Coordinator, prClient prClient, reviewClient review.PendingReviewClient) (*Gui, error) {
+func NewGui(cfg *config.Config, coord *Coordinator, prClient prClient, reviewClient review.PendingReviewClient, threadClient review.ThreadClient) (*Gui, error) {
 	vp := viewport.New()
 	g := &Gui{
-		config: cfg,
-		coord:  coord,
-		client: prClient,
-		focus:  layout.FocusPRs,
-		detail: &vp,
+		config:       cfg,
+		coord:        coord,
+		client:       prClient,
+		threadClient: threadClient,
+		focus:        layout.FocusPRs,
+		detail:       &vp,
 	}
 	revCtrl := review.NewController(cfg, coord, reviewClient, &g.diff, g.setReviewFocus)
+	revCtrl.SetThreadClient(threadClient)
 	g.review = revCtrl
 	coord.SetReviewHook(revCtrl)
 	return g, nil

--- a/internal/app/gui_test.go
+++ b/internal/app/gui_test.go
@@ -29,7 +29,7 @@ func TestGuiRun_LoadsPRsAndDetail(t *testing.T) {
 		ReleasePRs:     releasePRs,
 		ReleaseDetail:  releaseDetail,
 	}
-	g, err := NewGui(config.Default(), NewCoordinator(), client, client)
+	g, err := NewGui(config.Default(), NewCoordinator(), client, client, client)
 	if err != nil {
 		t.Fatalf("NewGui failed: %v", err)
 	}
@@ -102,7 +102,7 @@ func waitUntil(t *testing.T, cond func() bool, msg string) {
 
 func mustNewGui(t *testing.T, client *testmock.GHClient) *Gui {
 	t.Helper()
-	g, err := NewGui(config.Default(), NewCoordinator(), client, client)
+	g, err := NewGui(config.Default(), NewCoordinator(), client, client, client)
 	if err != nil {
 		t.Fatalf("NewGui failed: %v", err)
 	}

--- a/internal/app/input_test.go
+++ b/internal/app/input_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestModelUpdate_VKeyTogglesRangeSelection(t *testing.T) {
-	g, err := NewGui(config.Default(), NewCoordinator(), &testmock.GHClient{}, &testmock.GHClient{})
+	g, err := NewGui(config.Default(), NewCoordinator(), &testmock.GHClient{}, &testmock.GHClient{}, nil)
 	if err != nil {
 		t.Fatalf("NewGui failed: %v", err)
 	}
@@ -48,7 +48,7 @@ func TestModelUpdate_VKeyTogglesRangeSelection(t *testing.T) {
 }
 
 func TestModelUpdate_EnterKeyUsesRangeFlowAfterV(t *testing.T) {
-	g, err := NewGui(config.Default(), NewCoordinator(), &testmock.GHClient{}, &testmock.GHClient{})
+	g, err := NewGui(config.Default(), NewCoordinator(), &testmock.GHClient{}, &testmock.GHClient{}, nil)
 	if err != nil {
 		t.Fatalf("NewGui failed: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestModelUpdate_EnterKeyUsesRangeFlowAfterV(t *testing.T) {
 }
 
 func TestModelUpdate_EscCancelsCommentAndClearsRangeHighlight(t *testing.T) {
-	g, err := NewGui(config.Default(), NewCoordinator(), &testmock.GHClient{}, &testmock.GHClient{})
+	g, err := NewGui(config.Default(), NewCoordinator(), &testmock.GHClient{}, &testmock.GHClient{}, nil)
 	if err != nil {
 		t.Fatalf("NewGui failed: %v", err)
 	}
@@ -123,7 +123,7 @@ func TestModelUpdate_EscCancelsCommentAndClearsRangeHighlight(t *testing.T) {
 }
 
 func TestModelUpdate_EscClearsRangeSelectionWithoutLeavingDiff(t *testing.T) {
-	g, err := NewGui(config.Default(), NewCoordinator(), &testmock.GHClient{}, &testmock.GHClient{})
+	g, err := NewGui(config.Default(), NewCoordinator(), &testmock.GHClient{}, &testmock.GHClient{}, nil)
 	if err != nil {
 		t.Fatalf("NewGui failed: %v", err)
 	}
@@ -160,7 +160,7 @@ func TestModelUpdate_EscClearsRangeSelectionWithoutLeavingDiff(t *testing.T) {
 
 func TestModelUpdate_InputModeSubmitShortcutBypassesEditor(t *testing.T) {
 	mc := &testmock.GHClient{}
-	g, err := NewGui(config.Default(), NewCoordinator(), mc, mc)
+	g, err := NewGui(config.Default(), NewCoordinator(), mc, mc, mc)
 	if err != nil {
 		t.Fatalf("NewGui failed: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestModelUpdate_InputModeSubmitShortcutBypassesEditor(t *testing.T) {
 
 func TestModelUpdate_InputModeDiscardShortcutBypassesEditor(t *testing.T) {
 	mc := &testmock.GHClient{}
-	g, err := NewGui(config.Default(), NewCoordinator(), mc, mc)
+	g, err := NewGui(config.Default(), NewCoordinator(), mc, mc, mc)
 	if err != nil {
 		t.Fatalf("NewGui failed: %v", err)
 	}
@@ -216,7 +216,7 @@ func TestModelUpdate_InputModeDiscardShortcutBypassesEditor(t *testing.T) {
 }
 
 func TestModelUpdate_ReviewKeysIgnoredOutsideDiff(t *testing.T) {
-	g, err := NewGui(config.Default(), NewCoordinator(), &testmock.GHClient{}, &testmock.GHClient{})
+	g, err := NewGui(config.Default(), NewCoordinator(), &testmock.GHClient{}, &testmock.GHClient{}, nil)
 	if err != nil {
 		t.Fatalf("NewGui failed: %v", err)
 	}

--- a/internal/app/screen.go
+++ b/internal/app/screen.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/rin2yh/lazygh/internal/pr/overview"
 	"github.com/rin2yh/lazygh/internal/pr/review"
 )
 
@@ -26,8 +27,11 @@ func (s *screen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		s.gui.applyPRsResult(msg)
 		return s, nil
 	case detailLoadedMsg:
-		s.gui.applyDetailResult(msg)
-		return s, nil
+		cmd := s.gui.applyDetailResult(msg)
+		if msg.mode == overview.DetailModeDiff && msg.err == nil {
+			return s, tea.Batch(cmd, s.loadThreadsCmd(s.gui.coord.ListRepo(), msg.number))
+		}
+		return s, cmd
 	case review.CommentSavedMsg:
 		s.gui.review.CommentResult(msg)
 		return s, nil
@@ -42,6 +46,12 @@ func (s *screen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return s, nil
 	case review.DiscardedMsg:
 		s.gui.review.DiscardResult(msg)
+		return s, nil
+	case threadsLoadedMsg:
+		s.gui.applyThreadsResult(msg)
+		return s, nil
+	case review.ThreadReplyMsg:
+		s.gui.review.ThreadReplyResult(msg)
 		return s, nil
 	case tea.KeyMsg:
 		if s.gui.showHelp {

--- a/internal/config/action.go
+++ b/internal/config/action.go
@@ -30,6 +30,7 @@ const (
 	ActionReviewEditComment
 	ActionShowHelp
 	ActionFilterPRs
+	ActionReviewReplyThread
 )
 
 // ActionSpec holds an action's canonical name and default key bindings.
@@ -66,4 +67,5 @@ var actionSpecs = []ActionSpec{
 	{Action: ActionReviewEditComment, Name: "Review Edit Comment", DefaultKeys: []string{"i"}},
 	{Action: ActionShowHelp, Name: "Show Help", DefaultKeys: []string{"?"}},
 	{Action: ActionFilterPRs, Name: "Filter PRs", DefaultKeys: []string{"/"}},
+	{Action: ActionReviewReplyThread, Name: "Review Reply Thread", DefaultKeys: []string{"p"}},
 }

--- a/internal/gh/queries.go
+++ b/internal/gh/queries.go
@@ -84,4 +84,42 @@ const (
 				clientMutationId
 			}
 		}`
+
+	queryGetReviewThreads = `
+		query($owner: String!, $name: String!, $number: Int!) {
+			repository(owner: $owner, name: $name) {
+				pullRequest(number: $number) {
+					reviewThreads(first: 100) {
+						nodes {
+							id
+							path
+							line
+							diffSide
+							isResolved
+							isOutdated
+							comments(first: 50) {
+								nodes {
+									id
+									author { login }
+									body
+									createdAt
+								}
+							}
+						}
+					}
+				}
+			}
+		}`
+
+	mutationAddReplyToReviewThread = `
+		mutation($threadId: ID!, $body: String!) {
+			addPullRequestReviewThreadReply(input: {
+				pullRequestReviewThreadId: $threadId,
+				body: $body
+			}) {
+				comment {
+					id
+				}
+			}
+		}`
 )

--- a/internal/gh/review_client.go
+++ b/internal/gh/review_client.go
@@ -6,6 +6,25 @@ import (
 	"strings"
 )
 
+// ReviewThreadComment is a single comment within a review thread.
+type ReviewThreadComment struct {
+	ID        string `json:"id"`
+	Author    string
+	Body      string `json:"body"`
+	CreatedAt string `json:"createdAt"`
+}
+
+// ReviewThread represents an existing review thread on a PR.
+type ReviewThread struct {
+	ID         string `json:"id"`
+	Path       string `json:"path"`
+	Line       int    `json:"line"`
+	DiffSide   string `json:"diffSide"`
+	IsResolved bool   `json:"isResolved"`
+	IsOutdated bool   `json:"isOutdated"`
+	Comments   []ReviewThreadComment
+}
+
 // ReviewContext holds the identifiers needed to start or interact with a GitHub PR review.
 type ReviewContext struct {
 	PullRequestID string
@@ -188,6 +207,95 @@ func (c *Client) SubmitReview(_ string, reviewID string, event ReviewEvent, body
 		mutationSubmitReview,
 		"-f", "pullRequestReviewId="+reviewID,
 		"-f", "event="+string(event),
+		"-f", "body="+body,
+	)
+}
+
+func (c *Client) GetReviewThreads(repo string, number int) ([]ReviewThread, error) {
+	owner, name, err := splitRepo(repo)
+	if err != nil {
+		return nil, err
+	}
+	var resp struct {
+		Data struct {
+			Repository struct {
+				PullRequest struct {
+					ReviewThreads struct {
+						Nodes []struct {
+							ID         string `json:"id"`
+							Path       string `json:"path"`
+							Line       int    `json:"line"`
+							DiffSide   string `json:"diffSide"`
+							IsResolved bool   `json:"isResolved"`
+							IsOutdated bool   `json:"isOutdated"`
+							Comments   struct {
+								Nodes []struct {
+									ID     string `json:"id"`
+									Author struct {
+										Login string `json:"login"`
+									} `json:"author"`
+									Body      string `json:"body"`
+									CreatedAt string `json:"createdAt"`
+								} `json:"nodes"`
+							} `json:"comments"`
+						} `json:"nodes"`
+					} `json:"reviewThreads"`
+				} `json:"pullRequest"`
+			} `json:"repository"`
+		} `json:"data"`
+	}
+	if err := c.api.RunGraphQL(
+		&resp,
+		queryGetReviewThreads,
+		"-f", "owner="+owner,
+		"-f", "name="+name,
+		"-F", "number="+strconv.Itoa(number),
+	); err != nil {
+		return nil, err
+	}
+	nodes := resp.Data.Repository.PullRequest.ReviewThreads.Nodes
+	threads := make([]ReviewThread, 0, len(nodes))
+	for _, n := range nodes {
+		comments := make([]ReviewThreadComment, 0, len(n.Comments.Nodes))
+		for _, c := range n.Comments.Nodes {
+			comments = append(comments, ReviewThreadComment{
+				ID:        c.ID,
+				Author:    c.Author.Login,
+				Body:      c.Body,
+				CreatedAt: c.CreatedAt,
+			})
+		}
+		threads = append(threads, ReviewThread{
+			ID:         n.ID,
+			Path:       n.Path,
+			Line:       n.Line,
+			DiffSide:   n.DiffSide,
+			IsResolved: n.IsResolved,
+			IsOutdated: n.IsOutdated,
+			Comments:   comments,
+		})
+	}
+	return threads, nil
+}
+
+func (c *Client) AddReplyToReviewThread(threadID string, body string) error {
+	if strings.TrimSpace(threadID) == "" {
+		return fmt.Errorf("thread id is empty")
+	}
+	if strings.TrimSpace(body) == "" {
+		return fmt.Errorf("reply body is empty")
+	}
+	var resp struct {
+		Data struct {
+			AddPullRequestReviewThreadReply struct {
+				Comment struct {
+					ID string `json:"id"`
+				} `json:"comment"`
+			} `json:"addPullRequestReviewThreadReply"`
+		} `json:"data"`
+	}
+	return c.api.RunGraphQL(&resp, mutationAddReplyToReviewThread,
+		"-f", "threadId="+threadID,
 		"-f", "body="+body,
 	)
 }

--- a/internal/pr/review/controller.go
+++ b/internal/pr/review/controller.go
@@ -11,15 +11,18 @@ import (
 // Controller orchestrates the pending-review workflow and directly owns
 // ReviewState (no *state.State reference).
 type Controller struct {
-	rs         *ReviewState
-	isDiffMode func() bool
-	keys       config.KeyBindings
-	comment    *comment
-	summary    *summary
-	rng        *rangeState
-	pending    *pending
-	view       *view
-	setFocus   func(FocusTarget)
+	rs           *ReviewState
+	isDiffMode   func() bool
+	keys         config.KeyBindings
+	comment      *comment
+	summary      *summary
+	rng          *rangeState
+	pending      *pending
+	view         *view
+	setFocus     func(FocusTarget)
+	threadClient ThreadClient
+	app          AppState
+	threadReply  *threadReply
 }
 
 // NewController creates a Controller. app provides list/detail context;
@@ -30,17 +33,25 @@ func NewController(cfg *config.Config, app AppState, client PendingReviewClient,
 	s := newSummary(rs)
 	rng := newRange(rs, selection)
 	v := newView(rs, app, c, s)
+	tr := newThreadReply(cfg, rs)
 	return &Controller{
-		rs:         rs,
-		isDiffMode: app.IsDiffMode,
-		keys:       cfg.KeyBindings,
-		comment:    c,
-		summary:    s,
-		rng:        rng,
-		pending:    newPending(rs, app, client, selection, c, s),
-		view:       v,
-		setFocus:   setFocus,
+		rs:          rs,
+		isDiffMode:  app.IsDiffMode,
+		keys:        cfg.KeyBindings,
+		comment:     c,
+		summary:     s,
+		rng:         rng,
+		pending:     newPending(rs, app, client, selection, c, s),
+		view:        v,
+		setFocus:    setFocus,
+		app:         app,
+		threadReply: tr,
 	}
+}
+
+// SetThreadClient injects the client used to fetch and reply to review threads.
+func (c *Controller) SetThreadClient(tc ThreadClient) {
+	c.threadClient = tc
 }
 
 // --- Reader interface ---
@@ -94,6 +105,29 @@ func (c *Controller) BuildDrawerInput(showDrawer bool) *Input {
 	if inputMode == InputSummary {
 		input.SummaryInputLines = c.summary.Lines()
 	}
+	threads := c.rs.Threads
+	input.Threads = make([]DrawerThread, 0, len(threads))
+	for _, t := range threads {
+		dt := DrawerThread{
+			Path:       t.Path,
+			Line:       t.Line,
+			DiffSide:   t.DiffSide,
+			IsResolved: t.IsResolved,
+			IsOutdated: t.IsOutdated,
+			Comments:   make([]DrawerThreadComment, 0, len(t.Comments)),
+		}
+		for _, tc := range t.Comments {
+			dt.Comments = append(dt.Comments, DrawerThreadComment{
+				Author: tc.Author,
+				Body:   tc.Body,
+			})
+		}
+		input.Threads = append(input.Threads, dt)
+	}
+	input.SelectedThreadIdx = c.rs.SelectedThreadIdx
+	if inputMode == InputThreadReply {
+		input.ThreadReplyLines = c.threadReply.InputLines()
+	}
 	return input
 }
 
@@ -118,6 +152,12 @@ func (c *Controller) HandleCancel() bool {
 		c.setFocus(FocusDiffContent)
 		return true
 	}
+	if c.rs.InputMode == InputThreadReply {
+		c.threadReply.StopInput()
+		c.rs.StopInput()
+		c.setFocus(FocusReviewDrawer)
+		return true
+	}
 	if c.rs.InputMode != InputNone {
 		c.view.StopInput()
 		c.setFocus(FocusDiffContent)
@@ -140,6 +180,9 @@ func (c *Controller) HandleInputKey(msg tea.KeyMsg) (tea.Cmd, bool) {
 					return c.pending.HandleEditCommentSave(), true
 				}
 				return c.pending.HandleCommentSave(), true
+			}
+			if c.rs.InputMode == InputThreadReply {
+				return c.handleThreadReplySave(), true
 			}
 		}
 	}
@@ -173,12 +216,16 @@ func (c *Controller) HandleAction(action config.Action) tea.Cmd {
 		return c.pending.HandleDeleteComment()
 	case config.ActionReviewEditComment:
 		c.editComment()
+	case config.ActionReviewReplyThread:
+		c.beginThreadReply()
 	}
 	return nil
 }
 
 func (c *Controller) SelectNextComment() { c.pending.SelectNextComment() }
 func (c *Controller) SelectPrevComment() { c.pending.SelectPrevComment() }
+func (c *Controller) SelectNextThread()  { c.rs.SelectNextThread() }
+func (c *Controller) SelectPrevThread()  { c.rs.SelectPrevThread() }
 
 // --- Applier interface ---
 
@@ -211,6 +258,27 @@ func (c *Controller) EditCommentResult(msg CommentUpdatedMsg) {
 	if msg.Err == nil {
 		c.setFocus(FocusReviewDrawer)
 	}
+}
+
+func (c *Controller) ThreadsResult(msg ThreadsLoadedMsg) {
+	c.app.ClearFetching()
+	if msg.Err != nil {
+		c.rs.Notify(msg.Err.Error())
+		return
+	}
+	c.rs.LoadThreads(msg.Threads)
+}
+
+func (c *Controller) ThreadReplyResult(msg ThreadReplyMsg) {
+	c.app.ClearFetching()
+	c.threadReply.StopInput()
+	c.rs.StopInput()
+	if msg.Err != nil {
+		c.rs.Notify(msg.Err.Error())
+		return
+	}
+	c.rs.Notify("Reply posted.")
+	c.setFocus(FocusReviewDrawer)
 }
 
 // MarkStaleComments marks pending comments whose anchor position no longer
@@ -292,6 +360,8 @@ func (c *Controller) editorKey(msg tea.KeyMsg) (tea.Cmd, bool) {
 		return c.comment.HandleKey(msg)
 	case InputSummary:
 		return c.summary.HandleKey(msg)
+	case InputThreadReply:
+		return c.threadReply.HandleKey(msg)
 	default:
 		return nil, false
 	}
@@ -323,6 +393,38 @@ func (c *Controller) editComment() bool {
 
 func (c *Controller) saveComment() tea.Cmd { return c.pending.HandleCommentSave() }
 func (c *Controller) submit() tea.Cmd      { return c.pending.HandleSubmit() }
+
+func (c *Controller) beginThreadReply() {
+	if _, ok := c.rs.SelectedThread(); !ok {
+		c.rs.Notify("No thread selected.")
+		return
+	}
+	c.threadReply.BeginInput()
+	c.setFocus(FocusReviewDrawer)
+}
+
+func (c *Controller) handleThreadReplySave() tea.Cmd {
+	thread, ok := c.rs.SelectedThread()
+	if !ok {
+		c.rs.Notify("No thread selected.")
+		return nil
+	}
+	body := strings.TrimSpace(c.threadReply.CurrentValue())
+	if body == "" {
+		c.rs.Notify("Reply body is empty.")
+		return nil
+	}
+	if c.threadClient == nil {
+		c.rs.Notify("Thread client not available.")
+		return nil
+	}
+	threadID := thread.ID
+	c.app.BeginFetchReview()
+	return func() tea.Msg {
+		err := c.threadClient.AddReplyToReviewThread(threadID, body)
+		return ThreadReplyMsg{Err: err}
+	}
+}
 
 func (c *Controller) requireDiffMode(notice string, fn func()) tea.Cmd {
 	if !c.isDiffMode() {

--- a/internal/pr/review/drawer.go
+++ b/internal/pr/review/drawer.go
@@ -56,6 +56,41 @@ func (c DrawerComment) sanitize() string {
 	return strings.TrimSpace(sanitize.SingleLine(c.Body))
 }
 
+// DrawerThreadComment holds display data for a single comment within a thread.
+type DrawerThreadComment struct {
+	Author string
+	Body   string
+}
+
+// DrawerThread holds display data for an existing review thread.
+type DrawerThread struct {
+	Path       string
+	Line       int
+	DiffSide   string
+	IsResolved bool
+	IsOutdated bool
+	Comments   []DrawerThreadComment
+}
+
+func (t DrawerThread) Summary() string {
+	status := "open"
+	if t.IsResolved {
+		status = "resolved"
+	} else if t.IsOutdated {
+		status = "outdated"
+	}
+	location := DrawerRange{Path: t.Path, Line: t.Line}.String()
+	replies := len(t.Comments)
+	if replies == 0 {
+		return location + " [" + status + "] (no comments)"
+	}
+	first := strings.TrimSpace(sanitize.SingleLine(t.Comments[0].Body))
+	if len(first) > commentSummaryMaxLen {
+		first = first[:commentSummaryMaxLen] + "..."
+	}
+	return location + " [" + status + "] " + first + " (" + strconv.Itoa(replies) + ")"
+}
+
 type Input struct {
 	SummaryLines       []string
 	CommentModeLabel   string
@@ -67,6 +102,9 @@ type Input struct {
 	Notice             string
 	CommentInputLines  []string
 	SummaryInputLines  []string
+	Threads            []DrawerThread
+	SelectedThreadIdx  int
+	ThreadReplyLines   []string
 }
 
 func RenderDrawer(input Input, style widget.PanelStyle, width, height int) []string {
@@ -121,6 +159,37 @@ func RenderDrawer(input Input, style widget.PanelStyle, width, height int) []str
 		lines = append(lines, "")
 		lines = append(lines, "Summary Input [Ctrl+S save / Esc cancel]")
 		lines = append(lines, input.SummaryInputLines...)
+	}
+	if len(input.Threads) == 0 {
+		lines = append(lines, "")
+		lines = append(lines, "Threads: none")
+	} else {
+		lines = append(lines, "")
+		lines = append(lines, "Threads:")
+		for i, thread := range input.Threads {
+			prefix := "  - "
+			if i == input.SelectedThreadIdx {
+				prefix = "  > "
+			}
+			lines = append(lines, prefix+thread.Summary())
+			if i == input.SelectedThreadIdx {
+				for _, c := range thread.Comments {
+					author := c.Author
+					if author == "" {
+						author = "unknown"
+					}
+					body := strings.TrimSpace(c.Body)
+					for _, l := range strings.Split(body, "\n") {
+						lines = append(lines, "    ["+author+"] "+l)
+					}
+				}
+			}
+		}
+	}
+	if len(input.ThreadReplyLines) > 0 {
+		lines = append(lines, "")
+		lines = append(lines, "Reply Input [Ctrl+S save / Esc cancel]")
+		lines = append(lines, input.ThreadReplyLines...)
 	}
 	return widget.FramePanel("Review", lines, width, height, style)
 }

--- a/internal/pr/review/input_mode.go
+++ b/internal/pr/review/input_mode.go
@@ -7,4 +7,5 @@ const (
 	InputNone InputMode = iota
 	InputComment
 	InputSummary
+	InputThreadReply
 )

--- a/internal/pr/review/interfaces.go
+++ b/internal/pr/review/interfaces.go
@@ -43,6 +43,12 @@ type PendingReviewClient interface {
 	UpdatePendingReviewComment(commentID string, body string) error
 }
 
+// ThreadClient handles GitHub API calls for fetching and replying to review threads.
+type ThreadClient interface {
+	GetReviewThreads(repo string, number int) ([]gh.ReviewThread, error)
+	AddReplyToReviewThread(threadID string, body string) error
+}
+
 // Reader はGUIレイヤーが参照するレビュー状態の読み取りインターフェース。
 // BuildDrawerInput が描画用DTOを一括提供するため、個々の状態フィールドは含めない。
 type Reader interface {
@@ -63,6 +69,8 @@ type Handler interface {
 	HandleCancel() bool
 	SelectNextComment()
 	SelectPrevComment()
+	SelectNextThread()
+	SelectPrevThread()
 	Notify(msg string)
 }
 
@@ -74,4 +82,6 @@ type Applier interface {
 	SubmitResult(msg SubmittedMsg)
 	DiscardResult(msg DiscardedMsg)
 	MarkStaleComments(files []gh.DiffFile)
+	ThreadsResult(msg ThreadsLoadedMsg)
+	ThreadReplyResult(msg ThreadReplyMsg)
 }

--- a/internal/pr/review/pending.go
+++ b/internal/pr/review/pending.go
@@ -37,6 +37,17 @@ type DiscardedMsg struct {
 	Err error
 }
 
+// ThreadsLoadedMsg is returned after GetReviewThreads completes.
+type ThreadsLoadedMsg struct {
+	Threads []gh.ReviewThread
+	Err     error
+}
+
+// ThreadReplyMsg is returned after AddReplyToReviewThread completes.
+type ThreadReplyMsg struct {
+	Err error
+}
+
 type pending struct {
 	rs        *ReviewState
 	app       AppState

--- a/internal/pr/review/state.go
+++ b/internal/pr/review/state.go
@@ -1,6 +1,9 @@
 package review
 
-import "github.com/rin2yh/lazygh/pkg/sanitize"
+import (
+	"github.com/rin2yh/lazygh/internal/gh"
+	"github.com/rin2yh/lazygh/pkg/sanitize"
+)
 
 const noEditingComment = -1
 
@@ -19,6 +22,9 @@ type ReviewState struct {
 	Notice             string
 	SelectedCommentIdx int
 	EditingCommentIdx  int
+
+	Threads           []gh.ReviewThread
+	SelectedThreadIdx int
 }
 
 func newReviewState() *ReviewState {
@@ -174,6 +180,45 @@ func (rs *ReviewState) CycleEvent() {
 
 func (rs *ReviewState) ClearRangeStart() {
 	rs.RangeStart = nil
+}
+
+// LoadThreads stores fetched review threads.
+func (rs *ReviewState) LoadThreads(threads []gh.ReviewThread) {
+	rs.Threads = threads
+	rs.SelectedThreadIdx = 0
+}
+
+// SelectNextThread moves the thread selection down.
+func (rs *ReviewState) SelectNextThread() {
+	if len(rs.Threads) == 0 {
+		return
+	}
+	if rs.SelectedThreadIdx < len(rs.Threads)-1 {
+		rs.SelectedThreadIdx++
+	}
+}
+
+// SelectPrevThread moves the thread selection up.
+func (rs *ReviewState) SelectPrevThread() {
+	if rs.SelectedThreadIdx > 0 {
+		rs.SelectedThreadIdx--
+	}
+}
+
+// SelectedThread returns the currently selected review thread.
+func (rs *ReviewState) SelectedThread() (gh.ReviewThread, bool) {
+	idx := rs.SelectedThreadIdx
+	if idx < 0 || idx >= len(rs.Threads) {
+		return gh.ReviewThread{}, false
+	}
+	return rs.Threads[idx], true
+}
+
+// BeginThreadReplyInput switches to thread-reply input mode.
+func (rs *ReviewState) BeginThreadReplyInput() {
+	rs.DrawerOpen = true
+	rs.InputMode = InputThreadReply
+	rs.ClearNotice()
 }
 
 // Reset clears the review state entirely (e.g. when PR list reloads).

--- a/internal/pr/review/thread_reply.go
+++ b/internal/pr/review/thread_reply.go
@@ -1,0 +1,43 @@
+package review
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/rin2yh/lazygh/internal/config"
+	"github.com/rin2yh/lazygh/pkg/gui/textarea"
+)
+
+type threadReply struct {
+	keys config.KeyBindings
+	rs   *ReviewState
+	textarea.State
+}
+
+func newThreadReply(cfg *config.Config, rs *ReviewState) *threadReply {
+	return &threadReply{
+		keys:  cfg.KeyBindings,
+		rs:    rs,
+		State: textarea.New("Reply to thread"),
+	}
+}
+
+func (r *threadReply) BeginInput() {
+	r.rs.BeginThreadReplyInput()
+	r.Clear()
+	r.Focus()
+}
+
+func (r *threadReply) CurrentValue() string { return r.Text() }
+
+func (r *threadReply) InputLines() []string { return r.Lines() }
+
+func (r *threadReply) StopInput() {
+	r.Blur()
+	r.State.Clear()
+}
+
+func (r *threadReply) HandleKey(msg tea.KeyMsg) (tea.Cmd, bool) {
+	if r.keys.Matches(msg, config.ActionReviewSave) {
+		return nil, true
+	}
+	return r.Update(msg), true
+}

--- a/internal/pr/review/view.go
+++ b/internal/pr/review/view.go
@@ -25,7 +25,7 @@ func (f *view) ShouldShowDrawer() bool {
 		return false
 	}
 	rs := f.rs
-	return rs.DrawerOpen || rs.InputMode != InputNone || rs.HasPendingReview() || len(rs.Comments) > 0 || rs.Summary != "" || rs.RangeStart != nil
+	return rs.DrawerOpen || rs.InputMode != InputNone || rs.HasPendingReview() || len(rs.Comments) > 0 || rs.Summary != "" || rs.RangeStart != nil || len(rs.Threads) > 0
 }
 
 // StopInput stops any active input and returns the FocusTarget to move to

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ func main() {
 		os.Exit(1)
 	}
 	client := gh.NewClient()
-	g, err := app.NewGui(cfg, a.Coordinator, client, client)
+	g, err := app.NewGui(cfg, a.Coordinator, client, client, client)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)

--- a/pkg/test/mock/gh_client.go
+++ b/pkg/test/mock/gh_client.go
@@ -15,10 +15,12 @@ type GHClient struct {
 	PendingReviewID  string
 	PendingCommentID string
 	ReviewComments   []gh.ReviewComment
+	ReviewThreads    []gh.ReviewThread
 	SubmittedReviews []string
 	DeletedReviews   []string
 	DeletedComments  []string
 	UpdatedComments  []string
+	ThreadReplies    []string
 	Err              error
 }
 
@@ -83,6 +85,18 @@ func (m *GHClient) DeletePendingReview(_ string, reviewID string) error {
 		return m.Err
 	}
 	m.DeletedReviews = append(m.DeletedReviews, reviewID)
+	return nil
+}
+
+func (m *GHClient) GetReviewThreads(_ string, _ int) ([]gh.ReviewThread, error) {
+	return m.ReviewThreads, m.Err
+}
+
+func (m *GHClient) AddReplyToReviewThread(threadID string, body string) error {
+	if m.Err != nil {
+		return m.Err
+	}
+	m.ThreadReplies = append(m.ThreadReplies, threadID+":"+body)
 	return nil
 }
 
@@ -199,5 +213,13 @@ func (c *ControlledGHClient) SubmitReview(_ string, _ string, _ gh.ReviewEvent, 
 }
 
 func (c *ControlledGHClient) DeletePendingReview(_ string, _ string) error {
+	return c.Err
+}
+
+func (c *ControlledGHClient) GetReviewThreads(_ string, _ int) ([]gh.ReviewThread, error) {
+	return nil, c.Err
+}
+
+func (c *ControlledGHClient) AddReplyToReviewThread(_ string, _ string) error {
 	return c.Err
 }


### PR DESCRIPTION
## Summary

- `gh.ReviewThread` / `ReviewThreadComment` 型を追加し、GraphQL で既存スレッドを取得
- diff ロード後にスレッドを自動フェッチ、レビュードロワーに resolved/unresolved/outdated 状態と返信一覧を表示
- `p` キーで選択中スレッドへ返信できる `InputThreadReply` モードを追加
- PR 切り替え時のステールスレッド防止のため `prNumber` ガードを追加
- `ThreadClient` インターフェースを追加してモック可能にした

## Test plan

- [ ] `go test ./...` が全通過すること
- [ ] `go vet ./...` がエラーなしであること
- [ ] diff モードで PR を開いたとき、ドロワーに既存スレッドが表示されること
- [ ] `p` キーで返信入力フローが開始し、`Ctrl+S` で送信・`Esc` でキャンセルできること
- [ ] 異なる PR に素早く切り替えても、旧 PR のスレッドが表示されないこと

Closes #27

https://claude.ai/code/session_0127NTVSSgRcBVbzR9vWHJYR